### PR TITLE
Add Feinmann 8K / FO1 dongle driver, multi-profile support, and GUI redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.deb
 pulsar-x2a-linux_*_*/
 pulsar-mouse-linux_*_*/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Linux configuration tool for Pulsar gaming mice (X2A, X2H, Xlite, Feinmann 8K/FO1, Nordic)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = self.packages.${system}.pulsar-mouse-linux;
+
+          pulsar-mouse-linux = pkgs.python3Packages.buildPythonApplication {
+            pname = "pulsar-mouse-linux";
+            version = "0.1.0";
+            pyproject = true;
+
+            src = self;
+
+            build-system = [ pkgs.python3Packages.setuptools ];
+
+            dependencies = [
+              pkgs.python3Packages.pyusb
+              pkgs.python3Packages.pygobject3
+            ];
+
+            nativeBuildInputs = [
+              pkgs.wrapGAppsHook4
+              pkgs.gobject-introspection
+            ];
+
+            buildInputs = [
+              pkgs.gtk4
+              pkgs.libadwaita
+              pkgs.libdbusmenu
+            ];
+
+            # udev rules aren't picked up automatically from a Python build;
+            # ship them under lib/udev/rules.d so services.udev.packages
+            # (NixOS) or the package's own postinstall hook (other distros)
+            # can find them. Desktop file/icon likewise aren't part of the
+            # Python package itself.
+            postInstall = ''
+              install -Dm444 udev/50-pulsar-mouse.rules $out/lib/udev/rules.d/50-pulsar-mouse-linux.rules
+              install -Dm444 data/pulsar-mouse.desktop $out/share/applications/pulsar-mouse.desktop
+              install -Dm444 data/pulsar-mouse.svg $out/share/icons/hicolor/scalable/apps/pulsar-mouse.svg
+            '';
+
+            meta = {
+              description = "Linux configuration tool for Pulsar gaming mice";
+              homepage = "https://github.com/harveywuk/pulsar-mouse-linux";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "pulsar-mouse-gui";
+              platforms = pkgs.lib.platforms.linux;
+            };
+          };
+        }
+      );
+
+      # For consumers who'd rather bring this into their own nixpkgs
+      # instance (e.g. `nixpkgs.overlays = [ pulsar-mouse-linux.overlays.default ]`)
+      # than reference `packages.<system>.default` directly.
+      overlays.default = final: prev: {
+        pulsar-mouse-linux = self.packages.${prev.system}.pulsar-mouse-linux;
+      };
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/pulsar-mouse-gui";
+        };
+        cli = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/pulsar-mouse";
+        };
+      });
+    };
+}

--- a/src/pulsar_mouse/base.py
+++ b/src/pulsar_mouse/base.py
@@ -69,6 +69,23 @@ class PulsarDevice(ABC):
     def close(self) -> None:
         """Release the USB interface and re-attach the kernel driver."""
 
+    # ── Device information ──────────────────────────────────────────────────
+
+    def get_firmware_version(self) -> str:
+        """Return firmware version string from USB bcdDevice descriptor."""
+        return 'unknown'
+
+    # ── Active profile ───────────────────────────────────────────────────────
+    # Which profile the mouse actually uses during normal operation - distinct
+    # from get/set_dpi_stages() etc. above, which read/write a given profile's
+    # *stored* settings regardless of which one is currently active.
+
+    def get_active_profile(self) -> int:
+        raise NotImplementedError
+
+    def set_active_profile(self, profile: int) -> None:
+        raise NotImplementedError
+
     # ── Global settings ───────────────────────────────────────────────────
 
     @abstractmethod
@@ -168,3 +185,112 @@ class PulsarDevice(ABC):
     def parse_hidraw_event(self, data: bytes) -> Optional[dict]:
         """Parse a hidraw event. Return {'dpi': int, 'stage': int} or None."""
         return None
+
+    # ── Profile import / export ─────────────────────────────────────────────
+
+    def export_profile(self, profile: int) -> dict:
+        """Read all per-profile settings and return as a serialisable dict."""
+        from pulsar_mouse.hid import describe_button
+        caps = self.capabilities
+        data = {
+            'format': 'pulsar-mouse-profile',
+            'version': 1,
+            'device': caps.name,
+            'profile': profile,
+        }
+        try:
+            info = self.get_dpi_stages(profile)
+            data['dpi'] = {
+                'active': info['active'],
+                'stages': [dx for dx, _dy in info['stages'][:info['count']]],
+            }
+        except Exception:
+            pass
+        if caps.has_stage_colors:
+            try:
+                colors = []
+                stages = data.get('dpi', {}).get('stages')
+                n = len(stages) if stages else caps.max_dpi_stages
+                for i in range(1, n + 1):
+                    colors.append(list(self.get_stage_color(i, profile)))
+                data['stage_colors'] = colors
+            except Exception:
+                pass
+        if caps.lod_values:
+            try:
+                data['lod_mm'] = self.get_lod(profile)
+            except Exception:
+                pass
+        if caps.has_led:
+            try:
+                data['brightness'] = self.get_brightness(profile)
+            except Exception:
+                pass
+            try:
+                data['led_effect'] = self.get_led_effect(profile)
+            except Exception:
+                pass
+            if caps.has_breath_speed:
+                try:
+                    data['breath_speed'] = self.get_breath_speed(profile)
+                except Exception:
+                    pass
+        try:
+            buttons = {}
+            for name, bid in caps.buttons.items():
+                t, a1, a2 = self.get_button(bid, profile)
+                buttons[name] = describe_button(t, a1, a2)
+            data['buttons'] = buttons
+        except Exception:
+            pass
+        return data
+
+    def import_profile(self, profile: int, data: dict) -> list[str]:
+        """Apply profile settings from a dict. Returns list of warnings."""
+        from pulsar_mouse.hid import parse_button_function
+        caps = self.capabilities
+        warnings = []
+        if 'dpi' in data:
+            try:
+                dpi = data['dpi']
+                self.set_dpi_stages(dpi['stages'], dpi.get('active', 1), profile)
+            except Exception as e:
+                warnings.append(f'DPI: {e}')
+        if 'stage_colors' in data and caps.has_stage_colors:
+            for i, rgb in enumerate(data['stage_colors'], 1):
+                try:
+                    self.set_stage_color(i, rgb[0], rgb[1], rgb[2], profile)
+                except Exception as e:
+                    warnings.append(f'Stage {i} color: {e}')
+        if 'lod_mm' in data and caps.lod_values:
+            try:
+                self.set_lod(data['lod_mm'], profile)
+            except Exception as e:
+                warnings.append(f'LOD: {e}')
+        if 'brightness' in data and caps.has_led:
+            try:
+                self.set_brightness(data['brightness'], profile)
+            except Exception as e:
+                warnings.append(f'Brightness: {e}')
+        if 'led_effect' in data and caps.has_led:
+            try:
+                self.set_led_effect(data['led_effect'], profile)
+            except Exception as e:
+                warnings.append(f'LED effect: {e}')
+        if 'breath_speed' in data and caps.has_led and caps.has_breath_speed:
+            try:
+                self.set_breath_speed(data['breath_speed'], profile)
+            except Exception as e:
+                warnings.append(f'Breath speed: {e}')
+        if 'buttons' in data:
+            for name, func_str in data['buttons'].items():
+                bid = caps.buttons.get(name)
+                if bid is None:
+                    warnings.append(f'Button "{name}" not found on this device')
+                    continue
+                try:
+                    t, a1, a2 = parse_button_function(func_str)
+                    self.set_button(bid, t, a1, a2, profile)
+                except Exception as e:
+                    warnings.append(f'Button {name}: {e}')
+        return warnings

--- a/src/pulsar_mouse/base.py
+++ b/src/pulsar_mouse/base.py
@@ -27,7 +27,13 @@ class DeviceCapabilities:
 
     buttons: dict[str, int]                     # name -> button_id
     polling_rates: list[int]                    # [125, 250, 500, 1000]
-    lod_values: list[int]                       # [1, 2] in mm
+    lod_values: list[int]                       # [1, 2] in mm - or [lo, hi]
+                                                 # bounds when lod_step is set
+    # Set only on devices confirmed (via capture/live probe) to support
+    # sub-1mm LOD steps - lod_values is then just [lo, hi] and the GUI
+    # renders a slider instead of the discrete-choice dropdown every other
+    # driver uses. None (default) preserves the dropdown for everyone else.
+    lod_step: Optional[float] = None
 
     has_led: bool               = True
     led_effects: list[str]      = field(default_factory=lambda: ['off', 'steady', 'breath'])
@@ -135,10 +141,10 @@ class PulsarDevice(ABC):
 
     # ── Per-profile optional settings ─────────────────────────────────────
 
-    def get_lod(self, profile: int) -> int:
+    def get_lod(self, profile: int) -> float:
         raise NotImplementedError
 
-    def set_lod(self, mm: int, profile: int) -> None:
+    def set_lod(self, mm: float, profile: int) -> None:
         raise NotImplementedError
 
     def get_brightness(self, profile: int) -> int:

--- a/src/pulsar_mouse/cli.py
+++ b/src/pulsar_mouse/cli.py
@@ -6,6 +6,7 @@ Adapts dynamically to the connected device's capabilities.
 """
 
 import sys
+import json
 import argparse
 
 from pulsar_mouse import find_device, __version__
@@ -28,6 +29,16 @@ def _parse_bool(s, name):
 
 def print_global(device: PulsarDevice):
     caps = device.capabilities
+    try:
+        fw = device.get_firmware_version()
+        if fw != 'unknown':
+            print(f"  Firmware:         {fw}")
+    except Exception:
+        pass
+    try:
+        print(f"  Active profile:   {device.get_active_profile()}")
+    except Exception:
+        pass
     if hasattr(device, 'get_power'):
         try:
             pwr = device.get_power()
@@ -149,6 +160,8 @@ Examples:
 
   %(prog)s --profile 1 --button thumb1 dpi+
   %(prog)s --profile 1 --button thumb1 ctrl+c
+  %(prog)s --profile 1 --export profile1.json
+  %(prog)s --profile 1 --import profile1.json
   %(prog)s --profile 1 --reset
 """)
 
@@ -194,6 +207,10 @@ Examples:
                     type=int, help='Set DPI stage LED color (RGB 0-255)')
     pp.add_argument('--button', nargs=2, metavar=('BTN', 'FUNC'),
                     help='Remap a button')
+    pp.add_argument('--export', metavar='FILE',
+                    help='Export profile settings to JSON file')
+    pp.add_argument('--import', metavar='FILE', dest='import_file',
+                    help='Import profile settings from JSON file')
     pp.add_argument('--reset', action='store_true',
                     help='Reset profile to factory defaults')
 
@@ -219,12 +236,14 @@ def main():
         args.lod, args.dpi, args.active_stage,
         args.brightness, args.led, args.breath_speed,
         args.stage_color, args.button,
+        args.import_file,
     ])
 
     profile_required = args.reset or any(x is not None for x in [
         args.lod, args.dpi, args.active_stage,
         args.brightness, args.led, args.breath_speed,
         args.stage_color, args.button,
+        args.export, args.import_file,
     ])
 
     if profile_required and args.profile is None:
@@ -240,8 +259,29 @@ def main():
     if args.profile is not None and not 1 <= args.profile <= caps.num_profiles:
         sys.exit(f"Error: --profile must be 1–{caps.num_profiles}")
 
+    if args.export:
+        device.open()
+        try:
+            data = device.export_profile(args.profile)
+            with open(args.export, 'w') as f:
+                json.dump(data, f, indent=2)
+            print(f"Profile {args.profile} exported to {args.export}")
+        finally:
+            device.close()
+        return
+
     device.open()
     try:
+        if args.import_file:
+            with open(args.import_file) as f:
+                data = json.load(f)
+            if data.get('format') != 'pulsar-mouse-profile':
+                sys.exit("Error: not a valid pulsar-mouse profile file")
+            warnings = device.import_profile(args.profile, data)
+            print(f"Profile {args.profile} imported from {args.import_file}")
+            for w in warnings:
+                print(f"  Warning: {w}")
+
         if write_ops:
             # ── Global writes ─────────────────────────────────────────
             if args.poll is not None:

--- a/src/pulsar_mouse/cli.py
+++ b/src/pulsar_mouse/cli.py
@@ -193,8 +193,8 @@ Examples:
 
     # Per-profile settings
     pp = p.add_argument_group('per-profile settings (require --profile N)')
-    pp.add_argument('--lod', type=int, metavar='MM',
-                    help='Lift-off distance in mm')
+    pp.add_argument('--lod', type=float, metavar='MM',
+                    help='Lift-off distance in mm (some devices support 0.1mm steps)')
     pp.add_argument('--dpi', metavar='D1[,D2,...]',
                     help='Comma-separated DPI stage values')
     pp.add_argument('--active-stage', type=int, metavar='N',

--- a/src/pulsar_mouse/cli.py
+++ b/src/pulsar_mouse/cli.py
@@ -60,6 +60,16 @@ def print_global(device: PulsarDevice):
             print(f"  Motion sync:      {_on_off(device.get_motion_sync())}")
         except Exception as e:
             print(f"  Motion sync:      error ({e})")
+    if hasattr(device, 'get_power_saving_timeout'):
+        try:
+            print(f"  Power saving:     {device.get_power_saving_timeout()} s")
+        except Exception as e:
+            print(f"  Power saving:     error ({e})")
+    if hasattr(device, 'get_low_power_threshold'):
+        try:
+            print(f"  Low power mode:   {device.get_low_power_threshold()}%")
+        except Exception as e:
+            print(f"  Low power mode:   error ({e})")
 
 
 def print_profile(device: PulsarDevice, profile: int):
@@ -86,7 +96,11 @@ def print_profile(device: PulsarDevice, profile: int):
         try:
             effect = device.get_led_effect(profile)
             bright = device.get_brightness(profile)
-            if effect == 'breath' and caps.has_breath_speed:
+            # The pulsing effect's name varies per driver (feinmann8k.py:
+            # 'pulse', base.py's shared default: 'breath') - it's always
+            # the last entry in led_effects by convention, so check that
+            # way instead of a hardcoded name.
+            if caps.has_breath_speed and effect == caps.led_effects[-1]:
                 speed = device.get_breath_speed(profile)
                 print(f"  LED:              {effect}  speed={speed}/{caps.breath_speed_range[1]}  brightness={bright}/{caps.brightness_range[1]}")
             else:
@@ -159,6 +173,10 @@ Examples:
     g.add_argument('--angle-snap', metavar='on|off')
     g.add_argument('--ripple', metavar='on|off')
     g.add_argument('--motion-sync', metavar='on|off')
+    g.add_argument('--power-saving', type=int, metavar='SECONDS',
+                   help='Wireless power-saving timeout (30-900 seconds)')
+    g.add_argument('--low-power', type=int, metavar='PERCENT',
+                   help='Low power mode battery threshold (0-100)')
 
     # Per-profile settings
     pp = p.add_argument_group('per-profile settings (require --profile N)')
@@ -197,6 +215,7 @@ def main():
     write_ops = args.reset or any(x is not None for x in [
         args.poll, args.debounce,
         args.angle_snap, args.ripple, args.motion_sync,
+        args.power_saving, args.low_power,
         args.lod, args.dpi, args.active_stage,
         args.brightness, args.led, args.breath_speed,
         args.stage_color, args.button,
@@ -247,6 +266,14 @@ def main():
                 v = _parse_bool(args.motion_sync, 'motion-sync')
                 device.set_motion_sync(v)
                 print(f"Motion sync: {_on_off(v)}")
+
+            if args.power_saving is not None:
+                device.set_power_saving_timeout(args.power_saving)
+                print(f"Power saving timeout set to {args.power_saving} s")
+
+            if args.low_power is not None:
+                device.set_low_power_threshold(args.low_power)
+                print(f"Low power mode threshold set to {args.low_power}%")
 
             # ── Per-profile writes ────────────────────────────────────
             prof = args.profile

--- a/src/pulsar_mouse/cli.py
+++ b/src/pulsar_mouse/cli.py
@@ -187,18 +187,24 @@ def main():
 
     device_name = getattr(args, 'device', None)
 
-    write_ops = any([
+    # `is not None` (not plain truthiness) - `--debounce 0`, `--brightness 0`,
+    # `--breath-speed 0`, etc. are legitimate values, and a truthy check made
+    # them indistinguishable from the flag being omitted entirely, silently
+    # falling through to read-mode instead of performing the write.
+    # `args.reset` is a plain store_true flag, not an optional value, so it's
+    # checked separately rather than folded into the `is not None` list.
+    write_ops = args.reset or any(x is not None for x in [
         args.poll, args.debounce,
         args.angle_snap, args.ripple, args.motion_sync,
         args.lod, args.dpi, args.active_stage,
         args.brightness, args.led, args.breath_speed,
-        args.stage_color, args.button, args.reset,
+        args.stage_color, args.button,
     ])
 
-    profile_required = any([
+    profile_required = args.reset or any(x is not None for x in [
         args.lod, args.dpi, args.active_stage,
         args.brightness, args.led, args.breath_speed,
-        args.stage_color, args.button, args.reset,
+        args.stage_color, args.button,
     ])
 
     if profile_required and args.profile is None:

--- a/src/pulsar_mouse/cli.py
+++ b/src/pulsar_mouse/cli.py
@@ -32,7 +32,8 @@ def print_global(device: PulsarDevice):
         try:
             pwr = device.get_power()
             charging = "  (charging)" if pwr['power_connected'] else ""
-            print(f"  Battery:          {pwr['battery_percent']}%  {pwr['battery_mv']} mV{charging}")
+            mv = f"  {pwr['battery_mv']} mV" if pwr.get('battery_mv') is not None else ""
+            print(f"  Battery:          {pwr['battery_percent']}%{mv}{charging}")
         except Exception as e:
             print(f"  Battery:          error ({e})")
     try:

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -173,7 +173,7 @@ class PulsarFeinmann8K(PulsarDevice):
         self._poll_ack()
 
     def _query(self, cat, reg, sub, profile=0x01, payload=(),
-               match=None, timeout_ms=500, retries=3, apply_read_bit=True) -> bytes:
+               match=None, timeout_ms=500, retries=5, apply_read_bit=True) -> bytes:
         """Issue a read command and wait for its async reply on EP 0x82.
 
         `match` is an optional predicate over the raw reply bytes, used to

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -173,7 +173,7 @@ class PulsarFeinmann8K(PulsarDevice):
         self._poll_ack()
 
     def _query(self, cat, reg, sub, profile=0x01, payload=(),
-               match=None, timeout_ms=500, retries=3) -> bytes:
+               match=None, timeout_ms=500, retries=3, apply_read_bit=True) -> bytes:
         """Issue a read command and wait for its async reply on EP 0x82.
 
         `match` is an optional predicate over the raw reply bytes, used to
@@ -182,9 +182,16 @@ class PulsarFeinmann8K(PulsarDevice):
         depends on a live RF round-trip to the mouse, which occasionally
         drops a packet or arrives late - retry the whole request rather
         than just waiting longer on a single window.
+
+        `apply_read_bit` ORs `reg` with 0x80 to mark it as a read, matching
+        the convention most categories use (e.g. polling rate: 0x09 write /
+        0x89 read). Not universal though - the DPI-stage query (cat=0x05,
+        reg=0x01) was captured with the bare register and no write
+        counterpart, so callers for that one must pass False.
         """
+        build = self._build_read if apply_read_bit else self._build
         for attempt in range(retries):
-            self._set_report(self._build_read(cat, reg, sub, profile, payload))
+            self._set_report(build(cat, reg, sub, profile, payload))
             self._poll_ack()
             for resp in self._drain_responses(timeout_ms):
                 if match is None or match(resp):
@@ -213,7 +220,7 @@ class PulsarFeinmann8K(PulsarDevice):
         stages = []
         for stage in range(1, self.capabilities.max_dpi_stages + 1):
             resp = self._query(
-                0x05, 0x01, 0x02, 0x01, [stage],
+                0x05, 0x01, 0x02, 0x01, [stage], apply_read_bit=False,
                 match=lambda r: r[0] == 0x05 and r[1] == 0x05 and r[2] == stage)
             dpi = struct.unpack_from('<H', resp, 3)[0]
             stages.append((dpi, dpi))

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -5,13 +5,28 @@ USB protocol reverse-engineered from a Wireshark/USBPcap capture of Pulsar
 Fusion on Windows, then confirmed live against real hardware via pyusb.
 
 Same command framing as the Sonix X2A protocol (see x2a.py) — commands are
-sent on interface 3 as a 64-byte HID Feature report. Where this model
-differs: the Feature-report GET_REPORT reply is *never* real data, it is
-always a dead echo of the write buffer with byte[0] flipped 0x00->0x02
-(this is what made earlier direct probing look completely broken). Real
-read data instead arrives asynchronously as a 24-byte report on the
-interrupt IN endpoint 0x82, which belongs to interface 1 — so both
-interface 1 and interface 3 must be claimed.
+sent on interface 3 as a 64-byte HID Feature report. Every SET_REPORT is
+immediately followed by a GET_REPORT poll on the same report; this
+appears necessary for the device to act on the command, and for
+*read*-flavored queries (reg|0x80) a 2026-08-07 Windows/Fusion capture
+showed that GET_REPORT completion carrying real reply data rather than a
+dead echo (see _poll_ack()'s docstring for the byte layout). **This has
+NOT been reproduced live from Linux** despite extensive testing (byte-
+identical requests confirmed via a Linux-side usbmon trace, various
+delays/retries, draining the interrupt endpoint in parallel, sending the
+same SET_IDLE Windows sends first, a software USB reset, and a full
+physical replug) — on Linux the same request consistently gets the dead
+echo the original version of this file described. All of the get_*
+methods below that rely on this mechanism (everything except
+get_dpi_stages()) are therefore based on decoding the capture and
+cross-referencing the values against independently-known device state
+(exact hex match to a named GNOME palette color, exact match to factory-
+default button bindings, exact match to session values set moments
+earlier) rather than a live pyusb round-trip. High confidence, but flag
+this if one ever behaves oddly. get_dpi_stages() is unaffected — it still
+uses the async reply on interrupt IN endpoint 0x82 (interface 1), which
+does not have this problem — so both interface 1 and interface 3 must be
+claimed regardless.
 
 Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
   [0]     direction: 0x00=CMD (host->device)
@@ -24,12 +39,15 @@ Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
   [7-61]  payload
   [62-63] checksum: little-endian uint16 of sum(bytes[0:62])
 
-Every SET_REPORT is immediately followed by a GET_REPORT poll on the same
-report (this appears to be what makes the device execute the command /
-push its async reply — a bare SET_REPORT with no follow-up GET_REPORT was
-not tested and may not be sufficient).
+GET_REPORT reply format for read-flavored queries (same 64-byte report,
+byte[0] flipped from the request's 0x00 to 0x01): byte[1:4] echo the
+cat/reg/sub of the query, byte[6] echoes the profile, and byte[7:] holds
+the actual reply data in the same layout the write side used for that
+command (e.g. get_brightness's byte[8] lines up with set_brightness's
+payload=[0x01, value] landing at byte[7],byte[8]).
 
-Async reply format (interrupt IN, EP 0x82, up to 24 bytes):
+Async reply format (interrupt IN, EP 0x82, up to 24 bytes) — only used by
+get_dpi_stages():
   [0]     reply category (mirrors the command's category byte)
   [1]     reply subtype
   [2..]   payload, meaning depends on subtype
@@ -43,15 +61,17 @@ Confirmed subtypes:
                                               range shifted a lot between
                                               capture sessions)
 
-Status: PARTIALLY VERIFIED. Polling rate, DPI-stage read/write, LED
-brightness, angle snap, ripple control, motion sync, debounce, LOD, LED
-effect, breath speed, and stage colors are all live-verified against real
-hardware. Button bindings were observed as read-only queries in the
-capture with no decodable response, and are NOT implemented — see
-base.PulsarDevice defaults (NotImplementedError) for those. Note:
+Status: All writes are live-verified against real hardware. Reads
+(polling rate, debounce, LOD, angle snap, ripple control, motion sync,
+brightness, LED effect, breath speed, stage colors, active DPI stage,
+button bindings) are implemented and high-confidence but NOT live-
+verified from Linux - see the dead-echo note above. set_button() (writing
+a new binding) was never captured and is still NotImplemented. Note:
 get_dpi_stages() has a known side effect of also changing the active DPI
-stage (see its docstring) - no side-effect-free per-stage DPI read has
-been found yet.
+stage (see its docstring) - no side-effect-free per-stage DPI *value*
+read has been found yet, though get_active_dpi_stage() (just the index,
+not the six values) is side-effect-free (and does share the same
+unverified-on-Linux caveat as the other reads above).
 """
 
 import struct
@@ -88,7 +108,14 @@ class PulsarFeinmann8K(PulsarDevice):
         dpi_min=100,
         dpi_max=26000,
         dpi_step=100,
-        buttons={},                # not reverse-engineered yet
+        buttons={
+            'left':   0x01,
+            'right':  0x02,
+            'wheel':  0x03,
+            'thumb1': 0x04,   # left thumb front (default: forward)
+            'thumb2': 0x05,   # left thumb back  (default: backward)
+            'dpi':    0x0b,
+        },
         polling_rates=sorted(POLL_HZ_TO_VAL),
         # Confirmed 2026-08-07: on-wire protocol actually supports 0.1mm
         # steps (captured 0.7/1.0/2.0mm all as raw byte = mm*10), but the
@@ -96,6 +123,11 @@ class PulsarFeinmann8K(PulsarDevice):
         # mm - listing the two values every other model in this codebase
         # supports until the API is extended to carry finer precision.
         lod_values=[1, 2],
+        button_labels={
+            'left': 'Left Click', 'right': 'Right Click', 'wheel': 'Wheel Click',
+            'thumb1': 'Thumb 1 (forward)', 'thumb2': 'Thumb 2 (back)',
+            'dpi': 'DPI Button',
+        },
     )
 
     _WVALUE = 0x0300      # HID Feature report, report ID 0
@@ -165,13 +197,30 @@ class PulsarFeinmann8K(PulsarDevice):
     def _poll_ack(self) -> bytes:
         """GET_REPORT poll that follows every SET_REPORT in the capture.
 
-        The returned bytes are a dead echo (byte[0] flips 0x00->0x02) -
-        not real data - but sending this poll appears necessary for the
-        device to act on the command and/or push its async reply.
+        For plain writes this is a dead echo (byte[0] flips 0x00->0x02) and
+        sending it just appears necessary for the device to act on the
+        command. But for *read*-flavored queries (reg|0x80, see
+        _build_read/_query_ctrl) a 2026-08-07 Windows/Fusion capture proved
+        this reply is NOT always a dead echo - it carries the real value for
+        most fields (debounce, LOD, angle snap/ripple/motion sync,
+        brightness, LED effect/breath speed, stage colors, active DPI
+        stage, button bindings, polling rate), mirroring the write payload
+        layout: byte[6]=profile echo, byte[7:]=actual data. The one
+        confirmed exception is get_dpi_stages() (see its docstring), which
+        still needs the async interrupt-endpoint reply.
         """
         return bytes(self._dev.ctrl_transfer(
             0xA1, 0x01, self._WVALUE,
             self.capabilities.interface_num, self.capabilities.report_size))
+
+    def _query_ctrl(self, cat, reg, sub, profile=0x01, payload=()) -> bytes:
+        """Read query whose reply comes back directly in the GET_REPORT
+        completion - see _poll_ack()'s docstring. Much simpler than _query()
+        (no interrupt-endpoint draining/retries needed) but only works for
+        the fields confirmed there.
+        """
+        self._set_report(self._build_read(cat, reg, sub, profile, payload))
+        return self._poll_ack()
 
     def _drain_responses(self, timeout_ms=300) -> list[bytes]:
         out = []
@@ -227,9 +276,15 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x01, 0x09, 0x02, 0x01, [val])
 
     def get_polling_rate(self) -> int:
-        # The read variant (cat=0x01, reg=0x89) was captured but its async
-        # reply was never observed/decoded - needs another capture pass.
-        raise NotImplementedError
+        # cat=0x01/reg=0x89(=0x09|0x80)/sub=0x02 - reply byte[7] is the same
+        # POLL_HZ_TO_VAL bitmask byte used for writes. Confirmed 2026-08-07
+        # via Windows capture: read back 0x08 (1000 Hz), matching the last
+        # rate set that session.
+        resp = self._query_ctrl(0x01, 0x09, 0x02)
+        val = resp[7]
+        if val not in POLL_VAL_TO_HZ:
+            raise IOError(f"Unknown polling rate byte 0x{val:02x}")
+        return POLL_VAL_TO_HZ[val]
 
     # Captured 2026-08-07: toggling each on Fusion produced a single-byte
     # SET_REPORT, cat=0x07/sub=0x02/profile=0x01, payload=[1 or 0], differing
@@ -238,21 +293,31 @@ class PulsarFeinmann8K(PulsarDevice):
     def set_angle_snap(self, enabled: bool) -> None:
         self._cmd(0x07, 0x04, 0x02, 0x01, [1 if enabled else 0])
 
+    def get_angle_snap(self) -> bool:
+        return bool(self._query_ctrl(0x07, 0x04, 0x02)[7])
+
     def set_ripple_control(self, enabled: bool) -> None:
         self._cmd(0x07, 0x03, 0x02, 0x01, [1 if enabled else 0])
+
+    def get_ripple_control(self) -> bool:
+        return bool(self._query_ctrl(0x07, 0x03, 0x02)[7])
 
     def set_motion_sync(self, enabled: bool) -> None:
         self._cmd(0x07, 0x05, 0x02, 0x01, [1 if enabled else 0])
 
+    def get_motion_sync(self) -> bool:
+        return bool(self._query_ctrl(0x07, 0x05, 0x02)[7])
+
     def set_debounce(self, ms: int) -> None:
         # Captured 2026-08-07: dragging the debounce slider 0->15 then back
         # to 0 in Fusion produced a linear single-byte SET_REPORT per step,
-        # cat=0x04/reg=0x03/sub=0x03/profile=0x01, payload=[ms]. Each set was
-        # followed by a read (reg=0x03|0x80) but its async reply was never
-        # captured - get_debounce() still unimplemented.
+        # cat=0x04/reg=0x03/sub=0x03/profile=0x01, payload=[ms].
         if not 0 <= ms <= 15:
             raise ValueError("Debounce must be 0-15 ms")
         self._cmd(0x04, 0x03, 0x03, 0x01, [ms])
+
+    def get_debounce(self) -> int:
+        return self._query_ctrl(0x04, 0x03, 0x03)[7]
 
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 
@@ -286,9 +351,13 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x05, 0x01, 0x02, 0x01, [stage])
 
     def get_active_dpi_stage(self, profile: int) -> int:
-        # A "05 08 <stage> <enabled>" reply was seen sporadically in the
-        # capture but never reliably correlated to a specific request.
-        raise NotImplementedError
+        # cat=0x05/reg=0x81(=0x01|0x80)/sub=0x02, no stage in the payload -
+        # confirmed 2026-08-07 via Windows capture to be a genuinely
+        # side-effect-free read (unlike get_dpi_stages() above, which reuses
+        # the *write* command cat=0x05/reg=0x01/sub=0x02 with a stage number
+        # and mutates the active stage as a result). Reply byte[7] is the
+        # active stage index.
+        return self._query_ctrl(0x05, 0x01, 0x02, profile)[7]
 
     def set_dpi_stages(self, stages: list[int], active: int, profile: int) -> None:
         # Only single-stage reads/active-stage switching were decoded;
@@ -296,7 +365,12 @@ class PulsarFeinmann8K(PulsarDevice):
         raise NotImplementedError
 
     def get_lod(self, profile: int) -> int:
-        raise NotImplementedError
+        # cat=0x07/reg=0x82(=0x02|0x80)/sub=0x03 - reply byte[8] is raw =
+        # mm*10, same encoding as the write (see set_lod below). Confirmed
+        # 2026-08-07 via Windows capture: read back 20 (2.0mm). Rounded to
+        # whole mm since the public API is int-only (see set_lod).
+        resp = self._query_ctrl(0x07, 0x02, 0x03, profile)
+        return round(resp[8] / 10)
 
     def set_lod(self, mm: int, profile: int) -> None:
         # Captured 2026-08-07: dragging the LOD slider 0.7mm -> 1.0mm ->
@@ -325,13 +399,18 @@ class PulsarFeinmann8K(PulsarDevice):
     def set_led_effect(self, effect: str, profile: int) -> None:
         # Captured 2026-08-07: cat=0x03/reg=0x04/sub=0x0f, payload=[0x01,
         # val] - identical command and value mapping (off=0/steady=1/
-        # breath=2) to x2a.py's set_led_effect. Feinmann 8K's GET_REPORT is
-        # always a dead echo (see module docstring), so unlike x2a there's
-        # no working get_led_effect() here without a decoded async reply.
+        # breath=2) to x2a.py's set_led_effect.
         val = LED_NAME_TO_VAL.get(effect)
         if val is None:
             raise ValueError(f"Effect must be one of {list(LED_NAME_TO_VAL)}")
         self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, val])
+
+    def get_led_effect(self, profile: int) -> str:
+        # Same command as the write (cat=0x03/reg=0x84/sub=0x0f), reply
+        # byte[8] is the effect enum - confirmed 2026-08-07 via Windows
+        # capture (see get_breath_speed for the rest of this reply).
+        val = self._query_ctrl(0x03, 0x04, 0x0F, profile)[8]
+        return LED_VAL_TO_NAME.get(val, f'unknown(0x{val:02x})')
 
     def set_breath_speed(self, speed: int, profile: int) -> None:
         # Same command as set_led_effect, with effect pinned to breath (2)
@@ -346,8 +425,23 @@ class PulsarFeinmann8K(PulsarDevice):
             raise ValueError(f"Breath speed must be {lo}-{hi}")
         self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, 0x02, 0x00, 0x00, hi - speed])
 
+    def get_breath_speed(self, profile: int) -> int:
+        # Same reply as get_led_effect (cat=0x03/reg=0x84/sub=0x0f) -
+        # byte[11] is the raw inverted speed byte, same `hi - speed`
+        # encoding as the write. Confirmed 2026-08-07 via Windows capture:
+        # read back 100, matching `--breath-speed 0` set earlier that
+        # session (hi=100, so raw=hi-0=100).
+        hi = self.capabilities.breath_speed_range[1]
+        raw = self._query_ctrl(0x03, 0x04, 0x0F, profile)[11]
+        return hi - raw
+
     def get_brightness(self, profile: int) -> int:
-        raise NotImplementedError
+        # cat=0x03/reg=0x83(=0x03|0x80)/sub=0x03 - reply byte[8] is the
+        # brightness value, mirroring the write's payload=[0x01, value]
+        # (byte[7] is that same 0x01 marker). Confirmed 2026-08-07 via
+        # Windows capture: read back 0, matching brightness=0 set via the
+        # GUI earlier that session.
+        return self._query_ctrl(0x03, 0x03, 0x03, profile)[8]
 
     def set_stage_color(self, stage: int, r: int, g: int, b: int,
                         profile: int) -> None:
@@ -365,6 +459,34 @@ class PulsarFeinmann8K(PulsarDevice):
         if not 1 <= stage <= self.capabilities.max_dpi_stages:
             raise ValueError(f"Stage must be 1-{self.capabilities.max_dpi_stages}")
         self._cmd(0x05, 0x05, 0x05, 0x01, [stage, r, g, b])
+
+    def get_stage_color(self, stage: int, profile: int) -> tuple[int, int, int]:
+        # Same command as the write (cat=0x05/reg=0x85/sub=0x05,
+        # payload=[stage]) - reply byte[7] echoes the stage, bytes[8:11]
+        # are RGB. Confirmed 2026-08-07 via Windows capture: stage 1 read
+        # back as (237, 51, 59), an exact match for GNOME/Adwaita's named
+        # "Scarlet Red 3" palette swatch (#ED333B) set via the GUI color
+        # picker earlier that session - not a coincidence.
+        resp = self._query_ctrl(0x05, 0x05, 0x05, profile, [stage])
+        return (resp[8], resp[9], resp[10])
+
+    # ── Buttons ──────────────────────────────────────────────────────────────
+
+    def get_button(self, btn_id: int, profile: int) -> tuple[int, int, int]:
+        # cat=0x04/reg=0x81(=0x01|0x80)/sub=0x06, payload=[btn_id] - reply
+        # byte[7] echoes the button ID, byte[8]=type, byte[9]=a1,
+        # byte[10]=a2 (see hid.py's describe_button/BTN_TYPE_* for the
+        # encoding). Confirmed 2026-08-07 via Windows capture across all
+        # known button IDs on a factory-default mouse: left/right/wheel/
+        # thumb1/thumb2 decoded as BTN_TYPE_MOUSE with a1=their own ID
+        # (i.e. mouse(left)=1,1 mouse(right)=2,2 etc, matching
+        # hid.MOUSE_ACTIONS), and the dpi button (0x0b) decoded as
+        # BTN_TYPE_DPI/dpiloop (type=9, a1=3) - exactly the expected
+        # untouched defaults, which is what confirmed the byte offsets.
+        # Writing new bindings (set_button) was never captured and is
+        # still NotImplementedError (see base.PulsarDevice).
+        resp = self._query_ctrl(0x04, 0x01, 0x06, profile, [btn_id])
+        return (resp[8], resp[9], resp[10])
 
     # ── Hidraw support ───────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -44,10 +44,10 @@ Confirmed subtypes:
                                               capture sessions)
 
 Status: PARTIALLY VERIFIED. Polling rate, DPI-stage read/write, LED
-brightness, angle snap, ripple control, and motion sync are all
-live-verified against real hardware. Debounce, LOD, LED effect/breath,
-stage colors, and button bindings were observed as read-only queries in
-the capture with no decodable response, and are NOT implemented — see
+brightness, angle snap, ripple control, motion sync, debounce, and LOD are
+all live-verified against real hardware. LED effect/breath, stage colors,
+and button bindings were observed as read-only queries in the capture
+with no decodable response, and are NOT implemented — see
 base.PulsarDevice defaults (NotImplementedError) for those. Note:
 get_dpi_stages() has a known side effect of also changing the active DPI
 stage (see its docstring) - no side-effect-free per-stage DPI read has
@@ -86,7 +86,12 @@ class PulsarFeinmann8K(PulsarDevice):
         dpi_step=100,
         buttons={},                # not reverse-engineered yet
         polling_rates=sorted(POLL_HZ_TO_VAL),
-        lod_values=[1, 2],         # unconfirmed for this model
+        # Confirmed 2026-08-07: on-wire protocol actually supports 0.1mm
+        # steps (captured 0.7/1.0/2.0mm all as raw byte = mm*10), but the
+        # shared int-only set_lod()/--lod CLI interface only exposes whole
+        # mm - listing the two values every other model in this codebase
+        # supports until the API is extended to carry finer precision.
+        lod_values=[1, 2],
     )
 
     _WVALUE = 0x0300      # HID Feature report, report ID 0
@@ -229,6 +234,16 @@ class PulsarFeinmann8K(PulsarDevice):
     def set_motion_sync(self, enabled: bool) -> None:
         self._cmd(0x07, 0x05, 0x02, 0x01, [1 if enabled else 0])
 
+    def set_debounce(self, ms: int) -> None:
+        # Captured 2026-08-07: dragging the debounce slider 0->15 then back
+        # to 0 in Fusion produced a linear single-byte SET_REPORT per step,
+        # cat=0x04/reg=0x03/sub=0x03/profile=0x01, payload=[ms]. Each set was
+        # followed by a read (reg=0x03|0x80) but its async reply was never
+        # captured - get_debounce() still unimplemented.
+        if not 0 <= ms <= 15:
+            raise ValueError("Debounce must be 0-15 ms")
+        self._cmd(0x04, 0x03, 0x03, 0x01, [ms])
+
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 
     def get_dpi_stages(self, profile: int) -> dict:
@@ -269,6 +284,21 @@ class PulsarFeinmann8K(PulsarDevice):
         # Only single-stage reads/active-stage switching were decoded;
         # writing new DPI values for a stage was never captured.
         raise NotImplementedError
+
+    def get_lod(self, profile: int) -> int:
+        raise NotImplementedError
+
+    def set_lod(self, mm: int, profile: int) -> None:
+        # Captured 2026-08-07: dragging the LOD slider 0.7mm -> 1.0mm ->
+        # 2.0mm -> 0.7mm in Fusion produced cat=0x07/reg=0x02/sub=0x03,
+        # payload=[0x02, raw] where raw = mm*10 (0.7mm->7, 1.0mm->10,
+        # 2.0mm->20) - the device clearly supports 0.1mm steps, but the
+        # set_lod()/--lod interface here is int-only like every other
+        # driver in this codebase, so only whole-mm values are reachable
+        # through this method for now.
+        if mm not in self.capabilities.lod_values:
+            raise ValueError(f"LOD must be one of {self.capabilities.lod_values}")
+        self._cmd(0x07, 0x02, 0x03, 0x01, [0x02, mm * 10])
 
     # ── Per-profile: LED ─────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -285,9 +285,27 @@ class PulsarFeinmann8K(PulsarDevice):
             "(mouse may be asleep - try moving it or clicking a button)")
 
     def _cmd(self, cat, reg, sub, profile=0x01, payload=()) -> None:
-        """Fire a write command. No reply is expected/awaited."""
+        """Fire a write command. No reply is expected/awaited.
+
+        The GET_REPORT poll below only confirms the dongle accepted the
+        command over USB - it does NOT mean the command has finished
+        forwarding to the mouse over RF (same underlying latency as the
+        read side's "answer not ready yet" quirk in _query_ctrl()). Live-
+        verified 2026-08-07: two writes fired back-to-back with no delay
+        (e.g. set_brightness() immediately followed by set_breath_speed())
+        silently lose the *first* one - the dongle appears to have only
+        one in-flight RF command slot, and a second SET_REPORT before the
+        first has actually reached the mouse just overwrites it. Confirmed
+        with a single-byte payload difference between the affected
+        writes (different cat/reg pairs, not just LED-family commands
+        colliding), so the settle delay is applied unconditionally here
+        rather than only between specific settings known to be adjacent
+        in the GUI/CLI. 0.3s reliably avoided the drop in repeated tests;
+        anything close to 0s reproduced it every time.
+        """
         self._set_report(self._build(cat, reg, sub, profile, payload))
         self._poll_ack()
+        time.sleep(0.3)
 
     # ── Battery / power ──────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -7,27 +7,41 @@ Fusion on Windows, then confirmed live against real hardware via pyusb.
 Same command framing as the Sonix X2A protocol (see x2a.py) — commands are
 sent on interface 3 as a 64-byte HID Feature report. Every SET_REPORT is
 immediately followed by a GET_REPORT poll on the same report; this
-appears necessary for the device to act on the command, and for
-*read*-flavored queries (reg|0x80) a 2026-08-07 Windows/Fusion capture
-showed that GET_REPORT completion carrying real reply data rather than a
-dead echo (see _poll_ack()'s docstring for the byte layout). **This has
-NOT been reproduced live from Linux** despite extensive testing (byte-
-identical requests confirmed via a Linux-side usbmon trace, various
-delays/retries, draining the interrupt endpoint in parallel, sending the
-same SET_IDLE Windows sends first, a software USB reset, and a full
-physical replug) — on Linux the same request consistently gets the dead
-echo the original version of this file described. All of the get_*
-methods below (including get_dpi_stages() as of 2026-08-07 - see its
-docstring) are therefore based on decoding the capture and cross-
-referencing the values against independently-known device state (exact
-hex match to a named GNOME palette color, exact match to factory-default
-button bindings, exact match to session values set moments earlier, exact
-match to all six known DPI stage values in two independent capture
-instances) rather than a live pyusb round-trip. High confidence, but flag
-this if one ever behaves oddly. Only interface 3 is claimed - an earlier
-version of this file also claimed interface 1 for the interrupt-endpoint
-mechanism get_dpi_stages() used to rely on (see its docstring), but
-nothing here needs that anymore.
+appears necessary for the device to act on the command. For
+*read*-flavored queries (reg|0x80), a 2026-08-07 Windows/Fusion capture
+showed the GET_REPORT completion eventually carries real reply data
+rather than a dead echo (see _poll_ack()'s docstring for the byte
+layout) - but "eventually" is the key word that an earlier version of
+this file got wrong. The device needs a live RF round-trip to the mouse
+to answer, same as the (still interrupt-based) async replies elsewhere
+in this file: the *first* GET_REPORT poll after a read-flavored
+SET_REPORT is, essentially always, "not ready yet" (byte[0]=0x02), not a
+permanent dead echo. Fusion's own traffic (analyzed across its full
+~37k-packet capture, not just a handful of samples) never gets a real
+reply before ~15ms, and polls repeatedly - no new SET_REPORT, just
+GET_REPORT again - every ~15-30ms, up to ~250ms observed, until
+byte[0]=0x01. Earlier attempts at this treated the first poll's
+byte[0]=0x02 as final, or retried by resending a brand new SET_REPORT
+(which just restarts the same race) - both wrong. See _query_ctrl()'s
+docstring for the fixed polling loop, which is live-verified against
+real hardware. A handful of getters also needed request-byte fixes to
+match Windows' exact bytes byte-for-byte (see individual get_*
+docstrings) - discovered the same way, by directly diffing against the
+capture rather than assuming the write-side convention (profile=0x01,
+no extra marker bytes) carried over to reads unchanged. Writes need the
+same RF-round-trip settle time before a subsequent read reflects the
+new value - live-verified: reading immediately after writing can return
+the previous value, but the same read after ~0.5s settle time is
+accurate. This isn't a driver bug so much as an inherent property of the
+device (same class of RF latency as the pre-existing "mouse may be
+asleep" quirk on writes) - GUI/CLI usage at human timescales won't
+usually hit it, but back-to-back scripted set-then-verify should add a
+short sleep.
+
+Only interface 3 is claimed - an earlier version of this file also
+claimed interface 1 for the interrupt-endpoint mechanism
+get_dpi_stages() used to rely on (see its docstring), but nothing here
+needs that anymore.
 
 Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
   [0]     direction: 0x00=CMD (host->device)
@@ -69,19 +83,21 @@ Confirmed subtypes:
                                               range shifted a lot between
                                               capture sessions)
 
-Status: All writes, including set_button(), are implemented (see
-set_button()'s docstring - it's a same-command-as-x2a.py, byte-layout
-match rather than a live-verified changed-value capture). Every write
-except set_button() itself has been live-verified against real hardware.
-All reads (polling rate, debounce, LOD, angle snap, ripple control,
-motion sync, brightness, LED effect, breath speed, stage colors, DPI
-stages, active DPI stage, button bindings) are implemented and high-
-confidence but NOT live-verified from Linux - see the dead-echo note
-above. get_dpi_stages() is, as of 2026-08-07, genuinely side-effect-free
-(no longer mutates the active DPI stage - see its docstring for the fix).
+Status: FULLY VERIFIED. Every write except set_button() itself, and every
+read (polling rate, debounce, LOD, angle snap, ripple control, motion
+sync, brightness, LED effect, breath speed, stage colors, active DPI
+stage, all 6 DPI stage values, button bindings), is live-verified against
+real hardware via a full set-then-read-back pass on Linux - see
+_query_ctrl()'s docstring for how the read side was finally cracked.
+set_button() is implemented and ran cleanly against hardware, but has no
+live-verified *changed*-value confirmation (see its docstring) since no
+write for it was ever captured, only inferred from the read side's
+already-confirmed layout. get_dpi_stages() is genuinely side-effect-free
+(no longer mutates the active DPI stage - see its docstring).
 """
 
 import struct
+import time
 from typing import Optional
 
 import usb.core
@@ -199,32 +215,65 @@ class PulsarFeinmann8K(PulsarDevice):
                                  self.capabilities.interface_num, data)
 
     def _poll_ack(self) -> bytes:
-        """GET_REPORT poll that follows every SET_REPORT in the capture.
+        """GET_REPORT poll that follows every SET_REPORT.
 
-        For plain writes this is a dead echo (byte[0] flips 0x00->0x02) and
-        sending it just appears necessary for the device to act on the
-        command. But for *read*-flavored queries (reg|0x80, see
-        _build_read/_query_ctrl) a 2026-08-07 Windows/Fusion capture proved
-        this reply is NOT always a dead echo - it carries the real value for
-        most fields (debounce, LOD, angle snap/ripple/motion sync,
-        brightness, LED effect/breath speed, stage colors, active DPI
-        stage, button bindings, polling rate), mirroring the write payload
-        layout: byte[6]=profile echo, byte[7:]=actual data. The one
-        confirmed exception is get_dpi_stages() (see its docstring), which
-        still needs the async interrupt-endpoint reply.
+        For plain writes the immediate reply is a dead echo (byte[0]
+        flips 0x00->0x02) and sending it just appears necessary for the
+        device to act on the command. For *read*-flavored queries
+        (reg|0x80, see _build_read/_query_ctrl), byte[0]=0x02 does NOT
+        mean "dead echo" - it means "answer not ready yet, keep polling".
+        The real reply (byte[0]=0x01) requires a live RF round-trip to
+        the mouse and is NOT available on the first poll - see
+        _query_ctrl() for the actual polling loop. This single-shot
+        method just performs one GET_REPORT and returns whatever comes
+        back (busy or real), unfiltered.
         """
         return bytes(self._dev.ctrl_transfer(
             0xA1, 0x01, self._WVALUE,
             self.capabilities.interface_num, self.capabilities.report_size))
 
-    def _query_ctrl(self, cat, reg, sub, profile=0x01, payload=()) -> bytes:
-        """Read query whose reply comes back directly in the GET_REPORT
-        completion - see _poll_ack()'s docstring. Much simpler than _query()
-        (no interrupt-endpoint draining/retries needed) but only works for
-        the fields confirmed there.
+    def _query_ctrl(self, cat, reg, sub, profile=0x01, payload=(),
+                     initial_delay=0.05, poll_interval=0.02,
+                     timeout=1.0) -> bytes:
+        """Read query whose reply comes back in the GET_REPORT completion.
+
+        Root-caused 2026-08-07: earlier attempts at this treated a single
+        GET_REPORT poll's byte[0]=0x02 as a dead echo and gave up (or
+        retried by resending a brand new SET_REPORT, which just restarts
+        the same problem) - both wrong. Analysis of the full ~37k-packet
+        Windows capture (not just the earlier hand-picked samples) showed
+        Fusion's own GET_REPORT polls after a read-flavored SET_REPORT
+        never succeed before ~15ms (RF round-trip to the mouse), and it
+        keeps re-polling the SAME pending request - no new SET_REPORT -
+        every ~15-30ms until byte[0] flips to 0x01, observed up to ~250ms
+        in the wild. All of this session's earlier "delays/retries didn't
+        work" attempts used _query_ctrl()'s old single-poll version (or
+        equivalent), which polled within ~0.1-0.2ms of the SET_REPORT -
+        far too early - and none of them polled repeatedly *without*
+        resending SET_REPORT. Live-verified fixed: debounce, polling
+        rate, stage color, and active DPI stage all returned correct real
+        data with this exact polling loop.
+
+        Also guards against stale replies: ~10% of the device's real
+        (byte[0]=0x01) replies in the capture echoed a different cat/reg
+        than what was actually queried (a device-global latch, not a
+        per-request one) - only accept a reply whose byte[1:3] echoes the
+        cat/reg we asked for. (sub is deliberately not checked - see
+        get_dpi_stages()'s docstring for a command that legitimately
+        answers with a different sub than queried.)
         """
         self._set_report(self._build_read(cat, reg, sub, profile, payload))
-        return self._poll_ack()
+        time.sleep(initial_delay)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            resp = self._poll_ack()
+            if resp[0] == 0x01 and resp[1] == cat and resp[2] == (reg | 0x80):
+                return resp
+            time.sleep(poll_interval)
+        raise IOError(
+            f"No real reply from device for cat=0x{cat:02x} reg=0x{reg:02x} "
+            f"sub=0x{sub:02x} after {timeout*1000:.0f}ms of polling "
+            "(mouse may be asleep - try moving it or clicking a button)")
 
     def _cmd(self, cat, reg, sub, profile=0x01, payload=()) -> None:
         """Fire a write command. No reply is expected/awaited."""
@@ -240,11 +289,13 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x01, 0x09, 0x02, 0x01, [val])
 
     def get_polling_rate(self) -> int:
-        # cat=0x01/reg=0x89(=0x09|0x80)/sub=0x02 - reply byte[7] is the same
-        # POLL_HZ_TO_VAL bitmask byte used for writes. Confirmed 2026-08-07
-        # via Windows capture: read back 0x08 (1000 Hz), matching the last
-        # rate set that session.
-        resp = self._query_ctrl(0x01, 0x09, 0x02)
+        # cat=0x01/reg=0x89(=0x09|0x80)/sub=0x02, profile=0x00 (global
+        # settings are queried with profile=0 on the wire, unlike the
+        # profile=0x01 their *writes* use - confirmed against the Windows
+        # capture and live-verified: querying with the default profile=1
+        # here silently fails). Reply byte[7] is the same POLL_HZ_TO_VAL
+        # bitmask byte used for writes.
+        resp = self._query_ctrl(0x01, 0x09, 0x02, profile=0x00)
         val = resp[7]
         if val not in POLL_VAL_TO_HZ:
             raise IOError(f"Unknown polling rate byte 0x{val:02x}")
@@ -258,19 +309,21 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x07, 0x04, 0x02, 0x01, [1 if enabled else 0])
 
     def get_angle_snap(self) -> bool:
-        return bool(self._query_ctrl(0x07, 0x04, 0x02)[7])
+        # profile=0x00 on the wire for this read, like every other global
+        # setting - see get_polling_rate()'s comment.
+        return bool(self._query_ctrl(0x07, 0x04, 0x02, profile=0x00)[7])
 
     def set_ripple_control(self, enabled: bool) -> None:
         self._cmd(0x07, 0x03, 0x02, 0x01, [1 if enabled else 0])
 
     def get_ripple_control(self) -> bool:
-        return bool(self._query_ctrl(0x07, 0x03, 0x02)[7])
+        return bool(self._query_ctrl(0x07, 0x03, 0x02, profile=0x00)[7])
 
     def set_motion_sync(self, enabled: bool) -> None:
         self._cmd(0x07, 0x05, 0x02, 0x01, [1 if enabled else 0])
 
     def get_motion_sync(self) -> bool:
-        return bool(self._query_ctrl(0x07, 0x05, 0x02)[7])
+        return bool(self._query_ctrl(0x07, 0x05, 0x02, profile=0x00)[7])
 
     def set_debounce(self, ms: int) -> None:
         # Captured 2026-08-07: dragging the debounce slider 0->15 then back
@@ -281,7 +334,7 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x04, 0x03, 0x03, 0x01, [ms])
 
     def get_debounce(self) -> int:
-        return self._query_ctrl(0x04, 0x03, 0x03)[7]
+        return self._query_ctrl(0x04, 0x03, 0x03, profile=0x00)[7]
 
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 
@@ -379,10 +432,11 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, val])
 
     def get_led_effect(self, profile: int) -> str:
-        # Same command as the write (cat=0x03/reg=0x84/sub=0x0f), reply
-        # byte[8] is the effect enum - confirmed 2026-08-07 via Windows
-        # capture (see get_breath_speed for the rest of this reply).
-        val = self._query_ctrl(0x03, 0x04, 0x0F, profile)[8]
+        # Same command as the write (cat=0x03/reg=0x84/sub=0x0f), with the
+        # same payload=[0x01] marker byte the write sends at byte[7] -
+        # querying without it gets no reply at all. Reply byte[8] is the
+        # effect enum (see get_breath_speed for the rest of this reply).
+        val = self._query_ctrl(0x03, 0x04, 0x0F, profile, [0x01])[8]
         return LED_VAL_TO_NAME.get(val, f'unknown(0x{val:02x})')
 
     def set_breath_speed(self, speed: int, profile: int) -> None:
@@ -399,22 +453,18 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, 0x02, 0x00, 0x00, hi - speed])
 
     def get_breath_speed(self, profile: int) -> int:
-        # Same reply as get_led_effect (cat=0x03/reg=0x84/sub=0x0f) -
-        # byte[11] is the raw inverted speed byte, same `hi - speed`
-        # encoding as the write. Confirmed 2026-08-07 via Windows capture:
-        # read back 100, matching `--breath-speed 0` set earlier that
-        # session (hi=100, so raw=hi-0=100).
+        # Same reply/marker-byte as get_led_effect (cat=0x03/reg=0x84/
+        # sub=0x0f, payload=[0x01]) - byte[11] is the raw inverted speed
+        # byte, same `hi - speed` encoding as the write.
         hi = self.capabilities.breath_speed_range[1]
-        raw = self._query_ctrl(0x03, 0x04, 0x0F, profile)[11]
+        raw = self._query_ctrl(0x03, 0x04, 0x0F, profile, [0x01])[11]
         return hi - raw
 
     def get_brightness(self, profile: int) -> int:
-        # cat=0x03/reg=0x83(=0x03|0x80)/sub=0x03 - reply byte[8] is the
-        # brightness value, mirroring the write's payload=[0x01, value]
-        # (byte[7] is that same 0x01 marker). Confirmed 2026-08-07 via
-        # Windows capture: read back 0, matching brightness=0 set via the
-        # GUI earlier that session.
-        return self._query_ctrl(0x03, 0x03, 0x03, profile)[8]
+        # cat=0x03/reg=0x83(=0x03|0x80)/sub=0x03, payload=[0x01] (same
+        # marker byte the write sends at byte[7] - querying without it
+        # gets no reply). Reply byte[8] is the brightness value.
+        return self._query_ctrl(0x03, 0x03, 0x03, profile, [0x01])[8]
 
     def set_stage_color(self, stage: int, r: int, g: int, b: int,
                         profile: int) -> None:
@@ -436,10 +486,12 @@ class PulsarFeinmann8K(PulsarDevice):
     def get_stage_color(self, stage: int, profile: int) -> tuple[int, int, int]:
         # Same command as the write (cat=0x05/reg=0x85/sub=0x05,
         # payload=[stage]) - reply byte[7] echoes the stage, bytes[8:11]
-        # are RGB. Confirmed 2026-08-07 via Windows capture: stage 1 read
+        # are RGB. First confirmed via a Windows capture (stage 1 read
         # back as (237, 51, 59), an exact match for GNOME/Adwaita's named
         # "Scarlet Red 3" palette swatch (#ED333B) set via the GUI color
-        # picker earlier that session - not a coincidence.
+        # picker earlier that session - not a coincidence), then live-
+        # verified via a full set-then-read-back round trip on Linux once
+        # _query_ctrl()'s polling loop was fixed - see its docstring.
         resp = self._query_ctrl(0x05, 0x05, 0x05, profile, [stage])
         return (resp[8], resp[9], resp[10])
 
@@ -459,17 +511,22 @@ class PulsarFeinmann8K(PulsarDevice):
         self._cmd(0x04, 0x01, 0x06, profile, [btn_id, btn_type, a1, a2])
 
     def get_button(self, btn_id: int, profile: int) -> tuple[int, int, int]:
-        # cat=0x04/reg=0x81(=0x01|0x80)/sub=0x06, payload=[btn_id] - reply
-        # byte[7] echoes the button ID, byte[8]=type, byte[9]=a1,
-        # byte[10]=a2 (see hid.py's describe_button/BTN_TYPE_* for the
-        # encoding). Confirmed 2026-08-07 via Windows capture across all
-        # known button IDs on a factory-default mouse: left/right/wheel/
-        # thumb1/thumb2 decoded as BTN_TYPE_MOUSE with a1=their own ID
-        # (i.e. mouse(left)=1,1 mouse(right)=2,2 etc, matching
-        # hid.MOUSE_ACTIONS), and the dpi button (0x0b) decoded as
-        # BTN_TYPE_DPI/dpiloop (type=9, a1=3) - exactly the expected
+        # cat=0x04/reg=0x81(=0x01|0x80)/sub=0x06, profile=0x00 (like the
+        # other global-flavored reads, button bindings are queried with
+        # profile=0 on the wire regardless of the `profile` argument -
+        # this device only has one profile anyway), payload=[btn_id,
+        # 0xff] (trailing 0xff marker byte - querying without it gets no
+        # reply). Reply byte[7] echoes the button ID, byte[8]=type,
+        # byte[9]=a1, byte[10]=a2 (see hid.py's describe_button/
+        # BTN_TYPE_* for the encoding). Confirmed 2026-08-07 via Windows
+        # capture across all known button IDs on a factory-default mouse:
+        # left/right/wheel/thumb1/thumb2 decoded as BTN_TYPE_MOUSE with
+        # a1=their own ID (i.e. mouse(left)=1,1 mouse(right)=2,2 etc,
+        # matching hid.MOUSE_ACTIONS), and the dpi button (0x0b) decoded
+        # as BTN_TYPE_DPI/dpiloop (type=9, a1=3) - exactly the expected
         # untouched defaults, which is what confirmed the byte offsets.
-        resp = self._query_ctrl(0x04, 0x01, 0x06, profile, [btn_id])
+        resp = self._query_ctrl(0x04, 0x01, 0x06, profile=0x00,
+                                 payload=[btn_id, 0xff])
         return (resp[8], resp[9], resp[10])
 
     # ── Hidraw support ───────────────────────────────────────────────────────

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -280,6 +280,34 @@ class PulsarFeinmann8K(PulsarDevice):
         self._set_report(self._build(cat, reg, sub, profile, payload))
         self._poll_ack()
 
+    # ── Battery / power ──────────────────────────────────────────────────────
+
+    def get_power(self) -> dict:
+        # cat=0x08/reg=0x81(=0x01|0x80)/sub=0x01, profile=0x00, no payload -
+        # reply byte[6] is the battery percentage directly (0-100), unlike
+        # most other reads here where the value sits at byte[7]/[8]. Live-
+        # verified twice minutes apart, both times a plausible/stable
+        # value (88, matching the low-90s range this same field showed in
+        # two earlier Windows captures on a presumably similarly-charged
+        # battery). No millivolt reading has been found for this model -
+        # this device may just not expose one. get_power() is optional
+        # per-driver (base.PulsarDevice has no default for it - cli.py
+        # only calls it via hasattr()), and cli.py's print_global()
+        # tolerates a driver that omits 'battery_mv' from the dict.
+        pct = self._query_ctrl(0x08, 0x01, 0x01, profile=0x00)[6]
+        # cat=0x08/reg=0x83(=0x03|0x80)/sub=0x01, profile=0x00, no payload -
+        # reply byte[6] is 0 while unplugged (live-verified with the
+        # dongle's mouse not on a charging cable); never seen the charging
+        # (nonzero) case, but the command shape and byte offset match
+        # get_power's sibling field exactly, and cat=0x08 is otherwise
+        # unused for anything except this power-status pair.
+        charging = bool(self._query_ctrl(0x08, 0x03, 0x01, profile=0x00)[6])
+        return {
+            'battery_percent': pct,
+            'power_connected': charging,
+            'battery_mv': None,
+        }
+
     # ── Global settings ─────────────────────────────────────────────────────
 
     def set_polling_rate(self, hz: int) -> None:

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -261,9 +261,11 @@ class PulsarFeinmann8K(PulsarDevice):
         lo, hi = self.capabilities.brightness_range
         if not lo <= value <= hi:
             raise ValueError(f"Brightness must be {lo}-{hi}")
-        # Decoded from capture only (levels 7, 10, 20 tested) - not
-        # independently replayed against hardware this session.
-        self._cmd(0x07, 0x02, 0x03, 0x01, [0x02, value])
+        # Re-captured 2026-08-07: dragging the brightness slider in Fusion
+        # produced cat=0x03/reg=0x03/sub=0x03, payload=[0x01, value] every
+        # time - the old cat=0x07/reg=0x02/sub=0x03 payload=[0x02, value]
+        # guess was wrong in every field. Live-verified fixed.
+        self._cmd(0x03, 0x03, 0x03, 0x01, [0x01, value])
 
     def get_brightness(self, profile: int) -> int:
         raise NotImplementedError

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -130,6 +130,12 @@ class PulsarFeinmann8K(PulsarDevice):
                 self._dev.attach_kernel_driver(iface)
             except Exception:
                 pass
+        # release_interface()/attach_kernel_driver() only affect the
+        # interface claim - the underlying libusb device handle stays open
+        # until pyusb's backend is explicitly disposed (or GC eventually
+        # gets to it, which is not deterministic). Without this, the next
+        # open() races the leaked handle and fails with "Resource busy".
+        usb.util.dispose_resources(self._dev)
         self._dev = None
 
     # ── Low-level protocol helpers ──────────────────────────────────────────

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -49,8 +49,9 @@ Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
   [2]     register (bit7=0: write, bit7=1: read)
   [3]     sub-register
   [4-5]   always 0x00
-  [6]     profile (only ever observed as 0x01 in captures - device may
-          only expose a single onboard profile)
+  [6]     profile (1-6 - only 0x01 was seen in the original capture, but
+          live probing confirmed 6 independently addressable onboard
+          slots; 7+ time out with no reply)
   [7-61]  payload
   [62-63] checksum: little-endian uint16 of sum(bytes[0:62])
 
@@ -125,11 +126,16 @@ class PulsarFeinmann8K(PulsarDevice):
     """Driver for the Pulsar Feinmann 8K wireless dongle."""
 
     capabilities = DeviceCapabilities(
-        name='Pulsar Feinmann 8K Dongle',
+        name='Feinmann FO1',
         vid_pid_pairs=[(0x3710, 0x5404)],
         interface_num=3,          # commands (control transfers)
         report_size=64,
-        num_profiles=1,           # only ever saw profile byte == 0x01
+        # Live-verified 2026-08-08: profiles 1-6 all ack with a correctly
+        # echoed profile byte and stable, distinct per-slot data; 7+ time
+        # out with no reply. The earlier num_profiles=1 was wrong - it was
+        # inferred from the capture only ever showing writes to profile 1,
+        # not from an actual test of other profile bytes against hardware.
+        num_profiles=6,
         max_dpi_stages=6,
         dpi_min=100,
         dpi_max=26000,
@@ -199,6 +205,45 @@ class PulsarFeinmann8K(PulsarDevice):
         usb.util.dispose_resources(self._dev)
         self._dev = None
 
+    # ── Device information ────────────────────────────────────────────────
+
+    def get_firmware_version(self) -> str:
+        if self._dev is None:
+            return 'unknown'
+        try:
+            bcd = int(self._dev.bcdDevice)
+        except (TypeError, ValueError, AttributeError):
+            return 'unknown'
+        major = (bcd >> 12) & 0xF
+        minor = (bcd >> 8) & 0xF
+        patch = (bcd >> 4) & 0xF
+        build = bcd & 0xF
+        if patch or build:
+            return f'V{major}.{minor}.{patch}{build}'
+        return f'V{major}.{minor}'
+
+    # ── Active profile ───────────────────────────────────────────────────────
+    # cat=0x02/reg=0x06/sub=0x01 - identical command to x2a.py's active-
+    # profile register (this driver's docstring already notes several other
+    # commands, e.g. LED and button remap, are byte-identical to x2a.py's).
+    # Live-verified 2026-08-08: read with profile=0x00 or 0x01 (both give
+    # the same reply) returns the true active profile at byte[6] (byte[7]
+    # is 0 on this device, unlike some X2A units where the value can land
+    # there instead - x2a.py's `rsp[7] if rsp[7] else rsp[6]` fallback
+    # covers both). Write sends the target profile number directly as the
+    # profile byte, no separate payload - confirmed via a live switch-then-
+    # restore round trip (1 -> 2 -> back to 1).
+
+    def get_active_profile(self) -> int:
+        rsp = self._query_ctrl(0x02, 0x06, 0x01, profile=0x00)
+        return rsp[7] if rsp[7] else rsp[6]
+
+    def set_active_profile(self, profile: int) -> None:
+        if not 1 <= profile <= self.capabilities.num_profiles:
+            raise ValueError(
+                f"Profile must be 1-{self.capabilities.num_profiles}")
+        self._cmd(0x02, 0x06, 0x01, profile)
+
     # ── Low-level protocol helpers ──────────────────────────────────────────
 
     @staticmethod
@@ -221,7 +266,8 @@ class PulsarFeinmann8K(PulsarDevice):
 
     def _set_report(self, data: bytes) -> None:
         self._dev.ctrl_transfer(0x21, 0x09, self._WVALUE,
-                                 self.capabilities.interface_num, data)
+                                 self.capabilities.interface_num, data,
+                                 timeout=1000)
 
     def _poll_ack(self) -> bytes:
         """GET_REPORT poll that follows every SET_REPORT.
@@ -239,7 +285,8 @@ class PulsarFeinmann8K(PulsarDevice):
         """
         return bytes(self._dev.ctrl_transfer(
             0xA1, 0x01, self._WVALUE,
-            self.capabilities.interface_num, self.capabilities.report_size))
+            self.capabilities.interface_num, self.capabilities.report_size,
+            timeout=1000))
 
     def _query_ctrl(self, cat, reg, sub, profile=0x01, payload=(),
                      initial_delay=0.05, poll_interval=0.02,
@@ -461,7 +508,14 @@ class PulsarFeinmann8K(PulsarDevice):
         # get_dpi_stages() calls per-stage above. The earlier cat=0x04/
         # reg=0x01/sub=0x06 payload=[stage,0x01,stage] guess (inferred from
         # only 5 ambiguous samples) was wrong; live-verified fixed.
-        self._cmd(0x05, 0x01, 0x02, 0x01, [stage])
+        #
+        # `profile` was hardcoded to 0x01 here until 2026-08-08 (from when
+        # num_profiles=1 was assumed) - every write silently landed on
+        # profile 1 regardless of which profile the caller asked for. Now
+        # that profiles 1-6 are confirmed live and independently
+        # addressable (see capabilities.num_profiles above), it has to be
+        # threaded through like every other per-profile setter here.
+        self._cmd(0x05, 0x01, 0x02, profile, [stage])
 
     def get_active_dpi_stage(self, profile: int) -> int:
         # cat=0x05/reg=0x81(=0x01|0x80)/sub=0x02, no stage in the payload -
@@ -495,7 +549,7 @@ class PulsarFeinmann8K(PulsarDevice):
         # through this method for now.
         if mm not in self.capabilities.lod_values:
             raise ValueError(f"LOD must be one of {self.capabilities.lod_values}")
-        self._cmd(0x07, 0x02, 0x03, 0x01, [0x02, mm * 10])
+        self._cmd(0x07, 0x02, 0x03, profile, [0x02, mm * 10])
 
     # ── Per-profile: LED ─────────────────────────────────────────────────────
 
@@ -507,7 +561,7 @@ class PulsarFeinmann8K(PulsarDevice):
         # produced cat=0x03/reg=0x03/sub=0x03, payload=[0x01, value] every
         # time - the old cat=0x07/reg=0x02/sub=0x03 payload=[0x02, value]
         # guess was wrong in every field. Live-verified fixed.
-        self._cmd(0x03, 0x03, 0x03, 0x01, [0x01, value])
+        self._cmd(0x03, 0x03, 0x03, profile, [0x01, value])
 
     def set_led_effect(self, effect: str, profile: int) -> None:
         # Captured 2026-08-07: cat=0x03/reg=0x04/sub=0x0f, payload=[0x01,
@@ -516,7 +570,7 @@ class PulsarFeinmann8K(PulsarDevice):
         val = LED_NAME_TO_VAL.get(effect)
         if val is None:
             raise ValueError(f"Effect must be one of {list(LED_NAME_TO_VAL)}")
-        self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, val])
+        self._cmd(0x03, 0x04, 0x0F, profile, [0x01, val])
 
     def get_led_effect(self, profile: int) -> str:
         # Same command as the write (cat=0x03/reg=0x84/sub=0x0f), with the
@@ -537,7 +591,7 @@ class PulsarFeinmann8K(PulsarDevice):
         lo, hi = self.capabilities.breath_speed_range
         if not lo <= speed <= hi:
             raise ValueError(f"Breath speed must be {lo}-{hi}")
-        self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, 0x02, 0x00, 0x00, hi - speed])
+        self._cmd(0x03, 0x04, 0x0F, profile, [0x01, 0x02, 0x00, 0x00, hi - speed])
 
     def get_breath_speed(self, profile: int) -> int:
         # Same reply/marker-byte as get_led_effect (cat=0x03/reg=0x84/
@@ -568,7 +622,7 @@ class PulsarFeinmann8K(PulsarDevice):
                 raise ValueError(f"{name} must be 0-255")
         if not 1 <= stage <= self.capabilities.max_dpi_stages:
             raise ValueError(f"Stage must be 1-{self.capabilities.max_dpi_stages}")
-        self._cmd(0x05, 0x05, 0x05, 0x01, [stage, r, g, b])
+        self._cmd(0x05, 0x05, 0x05, profile, [stage, r, g, b])
 
     def get_stage_color(self, stage: int, profile: int) -> tuple[int, int, int]:
         # Same command as the write (cat=0x05/reg=0x85/sub=0x05,

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -217,6 +217,14 @@ class PulsarFeinmann8K(PulsarDevice):
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 
     def get_dpi_stages(self, profile: int) -> dict:
+        # WARNING: cat=0x05/reg=0x01/sub=0x02 is the *set active stage*
+        # command (see set_active_dpi_stage below) - re-captured traffic
+        # confirmed it's the same request Fusion sends when the user clicks
+        # to change stage. Calling this therefore leaves the mouse on
+        # whatever stage was queried last (stage 6 if the full loop
+        # completes), and can strand it on an earlier stage if a reply is
+        # missed mid-loop. Left as-is pending a real side-effect-free read;
+        # do not call this casually.
         stages = []
         for stage in range(1, self.capabilities.max_dpi_stages + 1):
             resp = self._query(
@@ -229,9 +237,13 @@ class PulsarFeinmann8K(PulsarDevice):
     def set_active_dpi_stage(self, stage: int, profile: int) -> None:
         if not 1 <= stage <= self.capabilities.max_dpi_stages:
             raise ValueError(f"DPI stage must be 1-{self.capabilities.max_dpi_stages}")
-        # Pattern confirmed from 5 samples in the capture (stages 1,2,3,4,5);
-        # stage index is repeated in the payload for reasons unconfirmed.
-        self._cmd(0x04, 0x01, 0x06, 0x01, [stage, 0x01, stage])
+        # Re-captured traffic (cycling stages 1->2->3->4->5->6->1 in Fusion)
+        # showed 7 SET_REPORTs, all cat=0x05/reg=0x01/sub=0x02 with a
+        # single-byte payload equal to the target stage - the same command
+        # get_dpi_stages() calls per-stage above. The earlier cat=0x04/
+        # reg=0x01/sub=0x06 payload=[stage,0x01,stage] guess (inferred from
+        # only 5 ambiguous samples) was wrong; live-verified fixed.
+        self._cmd(0x05, 0x01, 0x02, 0x01, [stage])
 
     def get_active_dpi_stage(self, profile: int) -> int:
         # A "05 08 <stage> <enabled>" reply was seen sporadically in the

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -113,7 +113,10 @@ POLL_HZ_TO_VAL = {125: 0x01, 250: 0x02, 500: 0x04, 1000: 0x08,
 POLL_VAL_TO_HZ = {v: k for k, v in POLL_HZ_TO_VAL.items()}
 
 # Same cat=0x03/reg=0x04/sub=0x0f command and value mapping as x2a.py.
-LED_NAME_TO_VAL = {'off': 0, 'steady': 1, 'breath': 2}
+# Named 'pulse' here (not base.DeviceCapabilities' shared default 'breath')
+# to match this model's actual name for the effect - overridden in
+# capabilities.led_effects below to match.
+LED_NAME_TO_VAL = {'off': 0, 'steady': 1, 'pulse': 2}
 LED_VAL_TO_NAME = {v: k for k, v in LED_NAME_TO_VAL.items()}
 
 
@@ -139,6 +142,11 @@ class PulsarFeinmann8K(PulsarDevice):
             'dpi':    0x0b,
         },
         polling_rates=sorted(POLL_HZ_TO_VAL),
+        # Overrides DeviceCapabilities' shared default (['off','steady',
+        # 'breath']) - this model's third LED effect is named 'pulse', not
+        # 'breath'. list(dict) preserves LED_NAME_TO_VAL's insertion order,
+        # so this always matches that dict's keys.
+        led_effects=list(LED_NAME_TO_VAL),
         # Confirmed 2026-08-07: on-wire protocol actually supports 0.1mm
         # steps (captured 0.7/1.0/2.0mm all as raw byte = mm*10), but the
         # shared int-only set_lod()/--lod CLI interface only exposes whole
@@ -307,6 +315,38 @@ class PulsarFeinmann8K(PulsarDevice):
             'power_connected': charging,
             'battery_mv': None,
         }
+
+    def set_power_saving_timeout(self, seconds: int) -> None:
+        # Fusion's "Wireless Power Saving" slider (30s-15min). Captured
+        # 2026-08-07 dragging it through its full range: cat=0x08/reg=0x05/
+        # sub=0x03, profile=0x01, payload=uint16 LE seconds directly - every
+        # value seen (30, 60, 120, ..., 900) round-tripped byte-exact, no
+        # scaling/offset needed.
+        if not 30 <= seconds <= 900:
+            raise ValueError("Power-saving timeout must be 30-900 seconds")
+        self._cmd(0x08, 0x05, 0x03, 0x01, list(struct.pack('<H', seconds)))
+
+    def get_power_saving_timeout(self) -> int:
+        # cat=0x08/reg=0x85(=0x05|0x80)/sub=0x03, profile=0x01, payload=
+        # [0x01] (marker byte - without it this gets no reply, same as
+        # get_brightness/get_led_effect). Reply bytes[7:9] are the same
+        # uint16 LE seconds value as the write.
+        resp = self._query_ctrl(0x08, 0x05, 0x03, profile=0x01, payload=[0x01])
+        return struct.unpack_from('<H', resp, 7)[0]
+
+    def set_low_power_threshold(self, percent: int) -> None:
+        # Fusion's "Low Power Mode" slider (0-100%). Captured 2026-08-07
+        # dragging it through its range: cat=0x08/reg=0x08/sub=0x02,
+        # profile=0x01, payload=[percent] directly, single byte, no
+        # scaling.
+        if not 0 <= percent <= 100:
+            raise ValueError("Low power threshold must be 0-100")
+        self._cmd(0x08, 0x08, 0x02, 0x01, [percent])
+
+    def get_low_power_threshold(self) -> int:
+        # cat=0x08/reg=0x88(=0x08|0x80)/sub=0x02, profile=0x00, no payload -
+        # reply byte[7] is the percentage directly.
+        return self._query_ctrl(0x08, 0x08, 0x02, profile=0x00)[7]
 
     # ── Global settings ─────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -17,16 +17,17 @@ delays/retries, draining the interrupt endpoint in parallel, sending the
 same SET_IDLE Windows sends first, a software USB reset, and a full
 physical replug) — on Linux the same request consistently gets the dead
 echo the original version of this file described. All of the get_*
-methods below that rely on this mechanism (everything except
-get_dpi_stages()) are therefore based on decoding the capture and
-cross-referencing the values against independently-known device state
-(exact hex match to a named GNOME palette color, exact match to factory-
-default button bindings, exact match to session values set moments
-earlier) rather than a live pyusb round-trip. High confidence, but flag
-this if one ever behaves oddly. get_dpi_stages() is unaffected — it still
-uses the async reply on interrupt IN endpoint 0x82 (interface 1), which
-does not have this problem — so both interface 1 and interface 3 must be
-claimed regardless.
+methods below (including get_dpi_stages() as of 2026-08-07 - see its
+docstring) are therefore based on decoding the capture and cross-
+referencing the values against independently-known device state (exact
+hex match to a named GNOME palette color, exact match to factory-default
+button bindings, exact match to session values set moments earlier, exact
+match to all six known DPI stage values in two independent capture
+instances) rather than a live pyusb round-trip. High confidence, but flag
+this if one ever behaves oddly. Only interface 3 is claimed - an earlier
+version of this file also claimed interface 1 for the interrupt-endpoint
+mechanism get_dpi_stages() used to rely on (see its docstring), but
+nothing here needs that anymore.
 
 Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
   [0]     direction: 0x00=CMD (host->device)
@@ -46,8 +47,12 @@ the actual reply data in the same layout the write side used for that
 command (e.g. get_brightness's byte[8] lines up with set_brightness's
 payload=[0x01, value] landing at byte[7],byte[8]).
 
-Async reply format (interrupt IN, EP 0x82, up to 24 bytes) — only used by
-get_dpi_stages():
+Async reply format (interrupt IN, EP 0x82, up to 24 bytes) — this driver
+no longer reads this endpoint itself (see get_dpi_stages()'s docstring
+for why), but it's what parse_hidraw_event() decodes from
+/dev/hidrawN for the GUI's live tray-icon DPI notifications (the kernel's
+hidraw layer exposes the same endpoint without needing pyusb to claim
+interface 1 - see the note above on why only interface 3 is claimed now):
   [0]     reply category (mirrors the command's category byte)
   [1]     reply subtype
   [2..]   payload, meaning depends on subtype
@@ -55,6 +60,9 @@ get_dpi_stages():
 Confirmed subtypes:
   05 05 <stage> <dpiLoLE16> <dpiLoLE16>   -- DPI value for `stage` (1-6),
                                               X and Y repeated, uint16 LE
+                                              (this is what's pushed when
+                                              the physical DPI button is
+                                              pressed, not a query reply)
   05 0d <val>                             -- periodic ~1Hz heartbeat,
                                               meaning unconfirmed (battery?
                                               signal? cursor rate? — value
@@ -65,19 +73,15 @@ Status: All writes, including set_button(), are implemented (see
 set_button()'s docstring - it's a same-command-as-x2a.py, byte-layout
 match rather than a live-verified changed-value capture). Every write
 except set_button() itself has been live-verified against real hardware.
-Reads (polling rate, debounce, LOD, angle snap, ripple control, motion
-sync, brightness, LED effect, breath speed, stage colors, active DPI
-stage, button bindings) are implemented and high-confidence but NOT live-
-verified from Linux - see the dead-echo note above. Note: get_dpi_stages()
-has a known side effect of also changing the active DPI stage (see its
-docstring) - no side-effect-free per-stage DPI *value* read has been
-found yet, though get_active_dpi_stage() (just the index,
-not the six values) is side-effect-free (and does share the same
-unverified-on-Linux caveat as the other reads above).
+All reads (polling rate, debounce, LOD, angle snap, ripple control,
+motion sync, brightness, LED effect, breath speed, stage colors, DPI
+stages, active DPI stage, button bindings) are implemented and high-
+confidence but NOT live-verified from Linux - see the dead-echo note
+above. get_dpi_stages() is, as of 2026-08-07, genuinely side-effect-free
+(no longer mutates the active DPI stage - see its docstring for the fix).
 """
 
 import struct
-import time
 from typing import Optional
 
 import usb.core
@@ -133,8 +137,6 @@ class PulsarFeinmann8K(PulsarDevice):
     )
 
     _WVALUE = 0x0300      # HID Feature report, report ID 0
-    _RESPONSE_IFACE = 1   # owns EP 0x82, separate from the command interface
-    _RESPONSE_EP = 0x82
 
     def __init__(self):
         self._dev = None
@@ -149,21 +151,21 @@ class PulsarFeinmann8K(PulsarDevice):
             raise RuntimeError(
                 f"{caps.name} not found (VID=0x{vid:04x}, PID=0x{pid:04x}). "
                 "Is the dongle plugged in?")
-        for iface in (caps.interface_num, self._RESPONSE_IFACE):
-            if dev.is_kernel_driver_active(iface):
-                dev.detach_kernel_driver(iface)
-            usb.util.claim_interface(dev, iface)
+        iface = caps.interface_num
+        if dev.is_kernel_driver_active(iface):
+            dev.detach_kernel_driver(iface)
+        usb.util.claim_interface(dev, iface)
         self._dev = dev
 
     def close(self) -> None:
         if self._dev is None:
             return
-        for iface in (self.capabilities.interface_num, self._RESPONSE_IFACE):
-            usb.util.release_interface(self._dev, iface)
-            try:
-                self._dev.attach_kernel_driver(iface)
-            except Exception:
-                pass
+        iface = self.capabilities.interface_num
+        usb.util.release_interface(self._dev, iface)
+        try:
+            self._dev.attach_kernel_driver(iface)
+        except Exception:
+            pass
         # release_interface()/attach_kernel_driver() only affect the
         # interface claim - the underlying libusb device handle stays open
         # until pyusb's backend is explicitly disposed (or GC eventually
@@ -224,50 +226,10 @@ class PulsarFeinmann8K(PulsarDevice):
         self._set_report(self._build_read(cat, reg, sub, profile, payload))
         return self._poll_ack()
 
-    def _drain_responses(self, timeout_ms=300) -> list[bytes]:
-        out = []
-        deadline = time.time() + timeout_ms / 1000.0
-        while time.time() < deadline:
-            try:
-                out.append(bytes(self._dev.read(
-                    self._RESPONSE_EP, 64, timeout=50)))
-            except usb.core.USBError:
-                pass
-        return out
-
     def _cmd(self, cat, reg, sub, profile=0x01, payload=()) -> None:
         """Fire a write command. No reply is expected/awaited."""
         self._set_report(self._build(cat, reg, sub, profile, payload))
         self._poll_ack()
-
-    def _query(self, cat, reg, sub, profile=0x01, payload=(),
-               match=None, timeout_ms=500, retries=5, apply_read_bit=True) -> bytes:
-        """Issue a read command and wait for its async reply on EP 0x82.
-
-        `match` is an optional predicate over the raw reply bytes, used to
-        pick the right reply out of the response stream (the device also
-        emits an unrelated ~1Hz heartbeat on the same endpoint). The reply
-        depends on a live RF round-trip to the mouse, which occasionally
-        drops a packet or arrives late - retry the whole request rather
-        than just waiting longer on a single window.
-
-        `apply_read_bit` ORs `reg` with 0x80 to mark it as a read, matching
-        the convention most categories use (e.g. polling rate: 0x09 write /
-        0x89 read). Not universal though - the DPI-stage query (cat=0x05,
-        reg=0x01) was captured with the bare register and no write
-        counterpart, so callers for that one must pass False.
-        """
-        build = self._build_read if apply_read_bit else self._build
-        for attempt in range(retries):
-            self._set_report(build(cat, reg, sub, profile, payload))
-            self._poll_ack()
-            for resp in self._drain_responses(timeout_ms):
-                if match is None or match(resp):
-                    return resp
-        raise IOError(
-            f"No matching response from device for cat=0x{cat:02x} "
-            f"reg=0x{reg:02x} sub=0x{sub:02x} after {retries} attempts "
-            "(mouse may be asleep - try moving it or clicking a button)")
 
     # ── Global settings ─────────────────────────────────────────────────────
 
@@ -324,22 +286,31 @@ class PulsarFeinmann8K(PulsarDevice):
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 
     def get_dpi_stages(self, profile: int) -> dict:
-        # WARNING: cat=0x05/reg=0x01/sub=0x02 is the *set active stage*
-        # command (see set_active_dpi_stage below) - re-captured traffic
-        # confirmed it's the same request Fusion sends when the user clicks
-        # to change stage. Calling this therefore leaves the mouse on
-        # whatever stage was queried last (stage 6 if the full loop
-        # completes), and can strand it on an earlier stage if a reply is
-        # missed mid-loop. Left as-is pending a real side-effect-free read;
-        # do not call this casually.
+        # Genuinely side-effect-free, unlike the previous implementation
+        # here (see git history) which reused the *set active stage*
+        # command per-stage and mutated the mouse's active stage as a
+        # result. Found 2026-08-07 in a capture of opening Fusion's DPI tab
+        # without touching any stage: cat=0x05/reg=0x04(bare)/sub=0x15, no
+        # stage in the payload (just profile) - a genuinely different
+        # command from set_active_dpi_stage's cat=0x05/reg=0x01/sub=0x02.
+        # Reply echoes back reg=0x84 as expected but oddly sub=0x21 rather
+        # than the queried 0x15 (harmless, ignored - not worth chasing).
+        # byte[7]=stage count, then `count` 5-byte blocks starting at
+        # byte[9]: [stage_num, dpi_x_lo, dpi_x_hi, dpi_y_lo, dpi_y_hi].
+        # Confirmed against all 6 known stage values (400/1200/2000/3200/
+        # 6400/12800) byte-exact, in two independent instances in the same
+        # capture.
+        resp = self._query_ctrl(0x05, 0x04, 0x15, profile)
+        count = resp[7]
         stages = []
-        for stage in range(1, self.capabilities.max_dpi_stages + 1):
-            resp = self._query(
-                0x05, 0x01, 0x02, 0x01, [stage], apply_read_bit=False,
-                match=lambda r: r[0] == 0x05 and r[1] == 0x05 and r[2] == stage)
-            dpi = struct.unpack_from('<H', resp, 3)[0]
-            stages.append((dpi, dpi))
-        return {'active': -1, 'count': len(stages), 'stages': stages}
+        off = 9
+        for _ in range(count):
+            x = struct.unpack_from('<H', resp, off + 1)[0]
+            y = struct.unpack_from('<H', resp, off + 3)[0]
+            stages.append((x, y))
+            off += 5
+        active = self.get_active_dpi_stage(profile)
+        return {'active': active, 'count': count, 'stages': stages}
 
     def set_active_dpi_stage(self, stage: int, profile: int) -> None:
         if not 1 <= stage <= self.capabilities.max_dpi_stages:

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -1,0 +1,255 @@
+"""
+Pulsar Feinmann 8K Dongle — protocol driver.
+
+USB protocol reverse-engineered from a Wireshark/USBPcap capture of Pulsar
+Fusion on Windows, then confirmed live against real hardware via pyusb.
+
+Same command framing as the Sonix X2A protocol (see x2a.py) — commands are
+sent on interface 3 as a 64-byte HID Feature report. Where this model
+differs: the Feature-report GET_REPORT reply is *never* real data, it is
+always a dead echo of the write buffer with byte[0] flipped 0x00->0x02
+(this is what made earlier direct probing look completely broken). Real
+read data instead arrives asynchronously as a 24-byte report on the
+interrupt IN endpoint 0x82, which belongs to interface 1 — so both
+interface 1 and interface 3 must be claimed.
+
+Packet format (64 bytes, sent via SET_REPORT, wValue=0x0300 Feature/ID0):
+  [0]     direction: 0x00=CMD (host->device)
+  [1]     command category
+  [2]     register (bit7=0: write, bit7=1: read)
+  [3]     sub-register
+  [4-5]   always 0x00
+  [6]     profile (only ever observed as 0x01 in captures - device may
+          only expose a single onboard profile)
+  [7-61]  payload
+  [62-63] checksum: little-endian uint16 of sum(bytes[0:62])
+
+Every SET_REPORT is immediately followed by a GET_REPORT poll on the same
+report (this appears to be what makes the device execute the command /
+push its async reply — a bare SET_REPORT with no follow-up GET_REPORT was
+not tested and may not be sufficient).
+
+Async reply format (interrupt IN, EP 0x82, up to 24 bytes):
+  [0]     reply category (mirrors the command's category byte)
+  [1]     reply subtype
+  [2..]   payload, meaning depends on subtype
+
+Confirmed subtypes:
+  05 05 <stage> <dpiLoLE16> <dpiLoLE16>   -- DPI value for `stage` (1-6),
+                                              X and Y repeated, uint16 LE
+  05 0d <val>                             -- periodic ~1Hz heartbeat,
+                                              meaning unconfirmed (battery?
+                                              signal? cursor rate? — value
+                                              range shifted a lot between
+                                              capture sessions)
+
+Status: PARTIALLY VERIFIED. Polling rate and DPI-stage read/write decoded
+and confirmed against a live device. LED brightness decoded from capture
+only (not independently replayed). Debounce, angle snap, ripple control,
+motion sync, LOD, LED effect/breath, stage colors, and button bindings
+were observed as read-only queries in the capture with no decodable
+response, and are NOT implemented — see base.PulsarDevice defaults
+(NotImplementedError) for those.
+"""
+
+import struct
+import time
+from typing import Optional
+
+import usb.core
+import usb.util
+
+from pulsar_mouse.base import PulsarDevice, DeviceCapabilities
+
+# ── Encoding tables ──────────────────────────────────────────────────────────
+
+# Bitmask, not sequential like X2A - extends up to 8000Hz.
+POLL_HZ_TO_VAL = {125: 0x01, 250: 0x02, 500: 0x04, 1000: 0x08,
+                  2000: 0x10, 4000: 0x20, 8000: 0x40}
+POLL_VAL_TO_HZ = {v: k for k, v in POLL_HZ_TO_VAL.items()}
+
+
+class PulsarFeinmann8K(PulsarDevice):
+    """Driver for the Pulsar Feinmann 8K wireless dongle."""
+
+    capabilities = DeviceCapabilities(
+        name='Pulsar Feinmann 8K Dongle',
+        vid_pid_pairs=[(0x3710, 0x5404)],
+        interface_num=3,          # commands (control transfers)
+        report_size=64,
+        num_profiles=1,           # only ever saw profile byte == 0x01
+        max_dpi_stages=6,
+        dpi_min=100,
+        dpi_max=26000,
+        dpi_step=100,
+        buttons={},                # not reverse-engineered yet
+        polling_rates=sorted(POLL_HZ_TO_VAL),
+        lod_values=[1, 2],         # unconfirmed for this model
+    )
+
+    _WVALUE = 0x0300      # HID Feature report, report ID 0
+    _RESPONSE_IFACE = 1   # owns EP 0x82, separate from the command interface
+    _RESPONSE_EP = 0x82
+
+    def __init__(self):
+        self._dev = None
+
+    # ── Connection lifecycle ────────────────────────────────────────────────
+
+    def open(self) -> None:
+        caps = self.capabilities
+        vid, pid = caps.vid_pid_pairs[0]
+        dev = usb.core.find(idVendor=vid, idProduct=pid)
+        if dev is None:
+            raise RuntimeError(
+                f"{caps.name} not found (VID=0x{vid:04x}, PID=0x{pid:04x}). "
+                "Is the dongle plugged in?")
+        for iface in (caps.interface_num, self._RESPONSE_IFACE):
+            if dev.is_kernel_driver_active(iface):
+                dev.detach_kernel_driver(iface)
+            usb.util.claim_interface(dev, iface)
+        self._dev = dev
+
+    def close(self) -> None:
+        if self._dev is None:
+            return
+        for iface in (self.capabilities.interface_num, self._RESPONSE_IFACE):
+            usb.util.release_interface(self._dev, iface)
+            try:
+                self._dev.attach_kernel_driver(iface)
+            except Exception:
+                pass
+        self._dev = None
+
+    # ── Low-level protocol helpers ──────────────────────────────────────────
+
+    @staticmethod
+    def _checksum(buf: bytearray) -> bytes:
+        return struct.pack('<H', sum(buf[:62]) & 0xFFFF)
+
+    def _build(self, cat, reg, sub, profile=0x01, payload=()):
+        buf = bytearray(64)
+        buf[1] = cat
+        buf[2] = reg
+        buf[3] = sub
+        buf[6] = profile
+        for i, b in enumerate(payload):
+            buf[7 + i] = b
+        buf[62:64] = self._checksum(buf)
+        return bytes(buf)
+
+    def _build_read(self, cat, reg, sub, profile=0x01, payload=()):
+        return self._build(cat, reg | 0x80, sub, profile, payload)
+
+    def _set_report(self, data: bytes) -> None:
+        self._dev.ctrl_transfer(0x21, 0x09, self._WVALUE,
+                                 self.capabilities.interface_num, data)
+
+    def _poll_ack(self) -> bytes:
+        """GET_REPORT poll that follows every SET_REPORT in the capture.
+
+        The returned bytes are a dead echo (byte[0] flips 0x00->0x02) -
+        not real data - but sending this poll appears necessary for the
+        device to act on the command and/or push its async reply.
+        """
+        return bytes(self._dev.ctrl_transfer(
+            0xA1, 0x01, self._WVALUE,
+            self.capabilities.interface_num, self.capabilities.report_size))
+
+    def _drain_responses(self, timeout_ms=300) -> list[bytes]:
+        out = []
+        deadline = time.time() + timeout_ms / 1000.0
+        while time.time() < deadline:
+            try:
+                out.append(bytes(self._dev.read(
+                    self._RESPONSE_EP, 64, timeout=50)))
+            except usb.core.USBError:
+                pass
+        return out
+
+    def _cmd(self, cat, reg, sub, profile=0x01, payload=()) -> None:
+        """Fire a write command. No reply is expected/awaited."""
+        self._set_report(self._build(cat, reg, sub, profile, payload))
+        self._poll_ack()
+
+    def _query(self, cat, reg, sub, profile=0x01, payload=(),
+               match=None, timeout_ms=300) -> bytes:
+        """Issue a read command and wait for its async reply on EP 0x82.
+
+        `match` is an optional predicate over the raw reply bytes, used to
+        pick the right reply out of the response stream (the device also
+        emits an unrelated ~1Hz heartbeat on the same endpoint).
+        """
+        self._set_report(self._build_read(cat, reg, sub, profile, payload))
+        self._poll_ack()
+        for resp in self._drain_responses(timeout_ms):
+            if match is None or match(resp):
+                return resp
+        raise IOError(
+            f"No matching response from device for cat=0x{cat:02x} "
+            f"reg=0x{reg:02x} sub=0x{sub:02x} within {timeout_ms}ms "
+            "(mouse may be asleep - try moving it or clicking a button)")
+
+    # ── Global settings ─────────────────────────────────────────────────────
+
+    def set_polling_rate(self, hz: int) -> None:
+        val = POLL_HZ_TO_VAL.get(hz)
+        if val is None:
+            raise ValueError(f"Polling rate must be one of {sorted(POLL_HZ_TO_VAL)}")
+        self._cmd(0x01, 0x09, 0x02, 0x01, [val])
+
+    def get_polling_rate(self) -> int:
+        # The read variant (cat=0x01, reg=0x89) was captured but its async
+        # reply was never observed/decoded - needs another capture pass.
+        raise NotImplementedError
+
+    # ── Per-profile: DPI stages ─────────────────────────────────────────────
+
+    def get_dpi_stages(self, profile: int) -> dict:
+        stages = []
+        for stage in range(1, self.capabilities.max_dpi_stages + 1):
+            resp = self._query(
+                0x05, 0x01, 0x02, 0x01, [stage],
+                match=lambda r: r[0] == 0x05 and r[1] == 0x05 and r[2] == stage)
+            dpi = struct.unpack_from('<H', resp, 3)[0]
+            stages.append((dpi, dpi))
+        return {'active': -1, 'count': len(stages), 'stages': stages}
+
+    def set_active_dpi_stage(self, stage: int, profile: int) -> None:
+        if not 1 <= stage <= self.capabilities.max_dpi_stages:
+            raise ValueError(f"DPI stage must be 1-{self.capabilities.max_dpi_stages}")
+        # Pattern confirmed from 5 samples in the capture (stages 1,2,3,4,5);
+        # stage index is repeated in the payload for reasons unconfirmed.
+        self._cmd(0x04, 0x01, 0x06, 0x01, [stage, 0x01, stage])
+
+    def get_active_dpi_stage(self, profile: int) -> int:
+        # A "05 08 <stage> <enabled>" reply was seen sporadically in the
+        # capture but never reliably correlated to a specific request.
+        raise NotImplementedError
+
+    def set_dpi_stages(self, stages: list[int], active: int, profile: int) -> None:
+        # Only single-stage reads/active-stage switching were decoded;
+        # writing new DPI values for a stage was never captured.
+        raise NotImplementedError
+
+    # ── Per-profile: LED ─────────────────────────────────────────────────────
+
+    def set_brightness(self, value: int, profile: int) -> None:
+        lo, hi = self.capabilities.brightness_range
+        if not lo <= value <= hi:
+            raise ValueError(f"Brightness must be {lo}-{hi}")
+        # Decoded from capture only (levels 7, 10, 20 tested) - not
+        # independently replayed against hardware this session.
+        self._cmd(0x07, 0x02, 0x03, 0x01, [0x02, value])
+
+    def get_brightness(self, profile: int) -> int:
+        raise NotImplementedError
+
+    # ── Hidraw support ───────────────────────────────────────────────────────
+
+    def parse_hidraw_event(self, data: bytes) -> Optional[dict]:
+        if len(data) >= 5 and data[0] == 0x05 and data[1] == 0x05:
+            dpi = struct.unpack_from('<H', data, 3)[0]
+            stage = data[2]
+            return {'dpi': dpi, 'stage': stage}
+        return None

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -154,12 +154,13 @@ class PulsarFeinmann8K(PulsarDevice):
         # 'breath'. list(dict) preserves LED_NAME_TO_VAL's insertion order,
         # so this always matches that dict's keys.
         led_effects=list(LED_NAME_TO_VAL),
-        # Confirmed 2026-08-07: on-wire protocol actually supports 0.1mm
-        # steps (captured 0.7/1.0/2.0mm all as raw byte = mm*10), but the
-        # shared int-only set_lod()/--lod CLI interface only exposes whole
-        # mm - listing the two values every other model in this codebase
-        # supports until the API is extended to carry finer precision.
-        lod_values=[1, 2],
+        # Confirmed 2026-08-07: on-wire protocol supports 0.1mm steps
+        # (captured 0.7/1.0/2.0mm all as raw byte = mm*10). 0.7-2.0mm is
+        # this model's full range (per spec/Fusion) - lod_values holds the
+        # [lo, hi] bounds rather than a discrete list since lod_step is
+        # set, telling the GUI to render a slider instead of a dropdown.
+        lod_values=[0.7, 2.0],
+        lod_step=0.1,
         button_labels={
             'left': 'Left Click', 'right': 'Right Click', 'wheel': 'Wheel Click',
             'thumb1': 'Thumb 1 (forward)', 'thumb2': 'Thumb 2 (back)',
@@ -531,25 +532,26 @@ class PulsarFeinmann8K(PulsarDevice):
         # writing new DPI values for a stage was never captured.
         raise NotImplementedError
 
-    def get_lod(self, profile: int) -> int:
+    def get_lod(self, profile: int) -> float:
         # cat=0x07/reg=0x82(=0x02|0x80)/sub=0x03 - reply byte[8] is raw =
         # mm*10, same encoding as the write (see set_lod below). Confirmed
         # 2026-08-07 via Windows capture: read back 20 (2.0mm). Rounded to
-        # whole mm since the public API is int-only (see set_lod).
+        # 1 decimal (not a whole mm) since 2026-08-08: this model's real
+        # range is 0.7-2.0mm in 0.1mm steps, per lod_values/lod_step above.
         resp = self._query_ctrl(0x07, 0x02, 0x03, profile)
-        return round(resp[8] / 10)
+        return round(resp[8] / 10, 1)
 
-    def set_lod(self, mm: int, profile: int) -> None:
+    def set_lod(self, mm: float, profile: int) -> None:
         # Captured 2026-08-07: dragging the LOD slider 0.7mm -> 1.0mm ->
         # 2.0mm -> 0.7mm in Fusion produced cat=0x07/reg=0x02/sub=0x03,
         # payload=[0x02, raw] where raw = mm*10 (0.7mm->7, 1.0mm->10,
-        # 2.0mm->20) - the device clearly supports 0.1mm steps, but the
-        # set_lod()/--lod interface here is int-only like every other
-        # driver in this codebase, so only whole-mm values are reachable
-        # through this method for now.
-        if mm not in self.capabilities.lod_values:
-            raise ValueError(f"LOD must be one of {self.capabilities.lod_values}")
-        self._cmd(0x07, 0x02, 0x03, profile, [0x02, mm * 10])
+        # 2.0mm->20) - live-verified 2026-08-08 across the full 0.7-2.0mm
+        # range. round() on the payload byte absorbs float imprecision
+        # (0.7 * 10 == 7.000000000000001 in Python).
+        lo, hi = self.capabilities.lod_values[0], self.capabilities.lod_values[-1]
+        if not lo - 1e-9 <= mm <= hi + 1e-9:
+            raise ValueError(f"LOD must be between {lo} and {hi} mm")
+        self._cmd(0x07, 0x02, 0x03, profile, [0x02, round(mm * 10)])
 
     # ── Per-profile: LED ─────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -43,13 +43,15 @@ Confirmed subtypes:
                                               range shifted a lot between
                                               capture sessions)
 
-Status: PARTIALLY VERIFIED. Polling rate and DPI-stage read/write decoded
-and confirmed against a live device. LED brightness decoded from capture
-only (not independently replayed). Debounce, angle snap, ripple control,
-motion sync, LOD, LED effect/breath, stage colors, and button bindings
-were observed as read-only queries in the capture with no decodable
-response, and are NOT implemented — see base.PulsarDevice defaults
-(NotImplementedError) for those.
+Status: PARTIALLY VERIFIED. Polling rate, DPI-stage read/write, LED
+brightness, angle snap, ripple control, and motion sync are all
+live-verified against real hardware. Debounce, LOD, LED effect/breath,
+stage colors, and button bindings were observed as read-only queries in
+the capture with no decodable response, and are NOT implemented — see
+base.PulsarDevice defaults (NotImplementedError) for those. Note:
+get_dpi_stages() has a known side effect of also changing the active DPI
+stage (see its docstring) - no side-effect-free per-stage DPI read has
+been found yet.
 """
 
 import struct
@@ -213,6 +215,19 @@ class PulsarFeinmann8K(PulsarDevice):
         # The read variant (cat=0x01, reg=0x89) was captured but its async
         # reply was never observed/decoded - needs another capture pass.
         raise NotImplementedError
+
+    # Captured 2026-08-07: toggling each on Fusion produced a single-byte
+    # SET_REPORT, cat=0x07/sub=0x02/profile=0x01, payload=[1 or 0], differing
+    # only by reg. Live-verified working (no async reply observed or needed,
+    # same as other fire-and-forget global settings).
+    def set_angle_snap(self, enabled: bool) -> None:
+        self._cmd(0x07, 0x04, 0x02, 0x01, [1 if enabled else 0])
+
+    def set_ripple_control(self, enabled: bool) -> None:
+        self._cmd(0x07, 0x03, 0x02, 0x01, [1 if enabled else 0])
+
+    def set_motion_sync(self, enabled: bool) -> None:
+        self._cmd(0x07, 0x05, 0x02, 0x01, [1 if enabled else 0])
 
     # ── Per-profile: DPI stages ─────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -61,15 +61,17 @@ Confirmed subtypes:
                                               range shifted a lot between
                                               capture sessions)
 
-Status: All writes are live-verified against real hardware. Reads
-(polling rate, debounce, LOD, angle snap, ripple control, motion sync,
-brightness, LED effect, breath speed, stage colors, active DPI stage,
-button bindings) are implemented and high-confidence but NOT live-
-verified from Linux - see the dead-echo note above. set_button() (writing
-a new binding) was never captured and is still NotImplemented. Note:
-get_dpi_stages() has a known side effect of also changing the active DPI
-stage (see its docstring) - no side-effect-free per-stage DPI *value*
-read has been found yet, though get_active_dpi_stage() (just the index,
+Status: All writes, including set_button(), are implemented (see
+set_button()'s docstring - it's a same-command-as-x2a.py, byte-layout
+match rather than a live-verified changed-value capture). Every write
+except set_button() itself has been live-verified against real hardware.
+Reads (polling rate, debounce, LOD, angle snap, ripple control, motion
+sync, brightness, LED effect, breath speed, stage colors, active DPI
+stage, button bindings) are implemented and high-confidence but NOT live-
+verified from Linux - see the dead-echo note above. Note: get_dpi_stages()
+has a known side effect of also changing the active DPI stage (see its
+docstring) - no side-effect-free per-stage DPI *value* read has been
+found yet, though get_active_dpi_stage() (just the index,
 not the six values) is side-effect-free (and does share the same
 unverified-on-Linux caveat as the other reads above).
 """
@@ -472,6 +474,19 @@ class PulsarFeinmann8K(PulsarDevice):
 
     # ── Buttons ──────────────────────────────────────────────────────────────
 
+    def set_button(self, btn_id: int, btn_type: int, a1: int, a2: int,
+                    profile: int) -> None:
+        # Found 2026-08-07 in the original broad pulsar.pcapng capture (not
+        # the later targeted ones): cat=0x04/reg=0x01(bare)/sub=0x06,
+        # payload=[btn_id, btn_type, a1, a2] - identical command to
+        # x2a.py's set_button. The captured instances were Fusion
+        # re-applying the untouched factory-default binding for each
+        # button (not an actual remap to something else), but the byte
+        # layout matches get_button()'s reply layout exactly (byte[7]=id,
+        # [8]=type, [9]=a1, [10]=a2), which is independently confirmed -
+        # high confidence despite no *changed*-value sample.
+        self._cmd(0x04, 0x01, 0x06, profile, [btn_id, btn_type, a1, a2])
+
     def get_button(self, btn_id: int, profile: int) -> tuple[int, int, int]:
         # cat=0x04/reg=0x81(=0x01|0x80)/sub=0x06, payload=[btn_id] - reply
         # byte[7] echoes the button ID, byte[8]=type, byte[9]=a1,
@@ -483,8 +498,6 @@ class PulsarFeinmann8K(PulsarDevice):
         # hid.MOUSE_ACTIONS), and the dpi button (0x0b) decoded as
         # BTN_TYPE_DPI/dpiloop (type=9, a1=3) - exactly the expected
         # untouched defaults, which is what confirmed the byte offsets.
-        # Writing new bindings (set_button) was never captured and is
-        # still NotImplementedError (see base.PulsarDevice).
         resp = self._query_ctrl(0x04, 0x01, 0x06, profile, [btn_id])
         return (resp[8], resp[9], resp[10])
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -173,21 +173,25 @@ class PulsarFeinmann8K(PulsarDevice):
         self._poll_ack()
 
     def _query(self, cat, reg, sub, profile=0x01, payload=(),
-               match=None, timeout_ms=300) -> bytes:
+               match=None, timeout_ms=500, retries=3) -> bytes:
         """Issue a read command and wait for its async reply on EP 0x82.
 
         `match` is an optional predicate over the raw reply bytes, used to
         pick the right reply out of the response stream (the device also
-        emits an unrelated ~1Hz heartbeat on the same endpoint).
+        emits an unrelated ~1Hz heartbeat on the same endpoint). The reply
+        depends on a live RF round-trip to the mouse, which occasionally
+        drops a packet or arrives late - retry the whole request rather
+        than just waiting longer on a single window.
         """
-        self._set_report(self._build_read(cat, reg, sub, profile, payload))
-        self._poll_ack()
-        for resp in self._drain_responses(timeout_ms):
-            if match is None or match(resp):
-                return resp
+        for attempt in range(retries):
+            self._set_report(self._build_read(cat, reg, sub, profile, payload))
+            self._poll_ack()
+            for resp in self._drain_responses(timeout_ms):
+                if match is None or match(resp):
+                    return resp
         raise IOError(
             f"No matching response from device for cat=0x{cat:02x} "
-            f"reg=0x{reg:02x} sub=0x{sub:02x} within {timeout_ms}ms "
+            f"reg=0x{reg:02x} sub=0x{sub:02x} after {retries} attempts "
             "(mouse may be asleep - try moving it or clicking a button)")
 
     # ── Global settings ─────────────────────────────────────────────────────

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -45,9 +45,9 @@ Confirmed subtypes:
 
 Status: PARTIALLY VERIFIED. Polling rate, DPI-stage read/write, LED
 brightness, angle snap, ripple control, motion sync, debounce, LOD, LED
-effect, and breath speed are all live-verified against real hardware.
-Stage colors and button bindings were observed as read-only queries in
-the capture with no decodable response, and are NOT implemented — see
+effect, breath speed, and stage colors are all live-verified against real
+hardware. Button bindings were observed as read-only queries in the
+capture with no decodable response, and are NOT implemented — see
 base.PulsarDevice defaults (NotImplementedError) for those. Note:
 get_dpi_stages() has a known side effect of also changing the active DPI
 stage (see its docstring) - no side-effect-free per-stage DPI read has
@@ -342,6 +342,23 @@ class PulsarFeinmann8K(PulsarDevice):
 
     def get_brightness(self, profile: int) -> int:
         raise NotImplementedError
+
+    def set_stage_color(self, stage: int, r: int, g: int, b: int,
+                        profile: int) -> None:
+        # Captured 2026-08-07: Fusion's LED tab auto-populated a rainbow
+        # preset across all 6 stages, giving a clean sample of this command
+        # at cat=0x05/reg=0x05/sub=0x05, payload=[stage, r, g, b] - byte-
+        # identical to x2a.py's set_stage_color (direct RGB, no inversion
+        # needed here unlike breath speed). Note: observing this traffic
+        # required cycling through all 6 stages in the UI, which - per
+        # get_dpi_stages()'s known side effect - also changed the mouse's
+        # active DPI stage each time; not an issue for this write itself.
+        for val, name in [(r, 'R'), (g, 'G'), (b, 'B')]:
+            if not 0 <= val <= 255:
+                raise ValueError(f"{name} must be 0-255")
+        if not 1 <= stage <= self.capabilities.max_dpi_stages:
+            raise ValueError(f"Stage must be 1-{self.capabilities.max_dpi_stages}")
+        self._cmd(0x05, 0x05, 0x05, 0x01, [stage, r, g, b])
 
     # ── Hidraw support ───────────────────────────────────────────────────────
 

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -96,6 +96,7 @@ already-confirmed layout. get_dpi_stages() is genuinely side-effect-free
 (no longer mutates the active DPI stage - see its docstring).
 """
 
+import glob
 import struct
 import time
 from typing import Optional
@@ -599,9 +600,41 @@ class PulsarFeinmann8K(PulsarDevice):
 
     # ── Hidraw support ───────────────────────────────────────────────────────
 
+    def find_hidraw(self) -> Optional[str]:
+        # DPI-change and signal-quality events (see parse_hidraw_event())
+        # arrive on interrupt endpoint 0x82, which belongs to interface 1
+        # - same pattern as x2a.py's find_hidraw(), just checking for
+        # interface 1 instead of x2a's interface 1 too (coincidentally
+        # the same number, not assumed to always be - confirmed via
+        # sysfs: hidraw2's HID_PHYS ends in /input1 and its device path
+        # resolves to this device's "...:1.1" (interface 1) node).
+        vid = f'{self.capabilities.vid_pid_pairs[0][0]:04x}'
+        for path in sorted(glob.glob('/sys/class/hidraw/hidraw*/device/uevent')):
+            try:
+                text = open(path).read()
+                if vid not in text.lower():
+                    continue
+                phys_line = [l for l in text.splitlines() if 'HID_PHYS' in l]
+                if phys_line and phys_line[0].endswith('/input1'):
+                    return '/dev/' + path.split('/')[4]
+            except OSError:
+                continue
+        return None
+
     def parse_hidraw_event(self, data: bytes) -> Optional[dict]:
         if len(data) >= 5 and data[0] == 0x05 and data[1] == 0x05:
             dpi = struct.unpack_from('<H', data, 3)[0]
             stage = data[2]
             return {'dpi': dpi, 'stage': stage}
+        # Periodic ~1Hz push, previously unidentified and suspected to be
+        # a duplicate battery-percent channel since its typical idle range
+        # (high 80s-90s) coincidentally overlapped get_power()'s battery
+        # reading. Confirmed 2026-08-07 via a Windows capture where the
+        # user moved the mouse away from the dongle mid-capture: this
+        # value dropped sharply (as low as 39) for the ~15s the mouse was
+        # far away, then recovered to 90-100 once moved back close -
+        # battery cannot fluctuate like that in 45 seconds, so this is
+        # wireless signal/connection quality (0-100), not battery.
+        if len(data) >= 3 and data[0] == 0x05 and data[1] == 0x0d:
+            return {'signal_percent': data[2]}
         return None

--- a/src/pulsar_mouse/drivers/feinmann8k.py
+++ b/src/pulsar_mouse/drivers/feinmann8k.py
@@ -44,10 +44,10 @@ Confirmed subtypes:
                                               capture sessions)
 
 Status: PARTIALLY VERIFIED. Polling rate, DPI-stage read/write, LED
-brightness, angle snap, ripple control, motion sync, debounce, and LOD are
-all live-verified against real hardware. LED effect/breath, stage colors,
-and button bindings were observed as read-only queries in the capture
-with no decodable response, and are NOT implemented — see
+brightness, angle snap, ripple control, motion sync, debounce, LOD, LED
+effect, and breath speed are all live-verified against real hardware.
+Stage colors and button bindings were observed as read-only queries in
+the capture with no decodable response, and are NOT implemented — see
 base.PulsarDevice defaults (NotImplementedError) for those. Note:
 get_dpi_stages() has a known side effect of also changing the active DPI
 stage (see its docstring) - no side-effect-free per-stage DPI read has
@@ -69,6 +69,10 @@ from pulsar_mouse.base import PulsarDevice, DeviceCapabilities
 POLL_HZ_TO_VAL = {125: 0x01, 250: 0x02, 500: 0x04, 1000: 0x08,
                   2000: 0x10, 4000: 0x20, 8000: 0x40}
 POLL_VAL_TO_HZ = {v: k for k, v in POLL_HZ_TO_VAL.items()}
+
+# Same cat=0x03/reg=0x04/sub=0x0f command and value mapping as x2a.py.
+LED_NAME_TO_VAL = {'off': 0, 'steady': 1, 'breath': 2}
+LED_VAL_TO_NAME = {v: k for k, v in LED_NAME_TO_VAL.items()}
 
 
 class PulsarFeinmann8K(PulsarDevice):
@@ -311,6 +315,30 @@ class PulsarFeinmann8K(PulsarDevice):
         # time - the old cat=0x07/reg=0x02/sub=0x03 payload=[0x02, value]
         # guess was wrong in every field. Live-verified fixed.
         self._cmd(0x03, 0x03, 0x03, 0x01, [0x01, value])
+
+    def set_led_effect(self, effect: str, profile: int) -> None:
+        # Captured 2026-08-07: cat=0x03/reg=0x04/sub=0x0f, payload=[0x01,
+        # val] - identical command and value mapping (off=0/steady=1/
+        # breath=2) to x2a.py's set_led_effect. Feinmann 8K's GET_REPORT is
+        # always a dead echo (see module docstring), so unlike x2a there's
+        # no working get_led_effect() here without a decoded async reply.
+        val = LED_NAME_TO_VAL.get(effect)
+        if val is None:
+            raise ValueError(f"Effect must be one of {list(LED_NAME_TO_VAL)}")
+        self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, val])
+
+    def set_breath_speed(self, speed: int, profile: int) -> None:
+        # Same command as set_led_effect, with effect pinned to breath (2)
+        # and a raw byte appended - same command shape as x2a.py's
+        # set_breath_speed, but live-tested 2026-08-07 and confirmed
+        # INVERTED on this model: raw=100 pulsed visibly slower than
+        # raw=5. Unlike x2a (which sends `speed` directly), the raw byte
+        # sent to the device is `hi - speed` so the public speed=0..100
+        # API stays intuitive (0=slowest, 100=fastest) across drivers.
+        lo, hi = self.capabilities.breath_speed_range
+        if not lo <= speed <= hi:
+            raise ValueError(f"Breath speed must be {lo}-{hi}")
+        self._cmd(0x03, 0x04, 0x0F, 0x01, [0x01, 0x02, 0x00, 0x00, hi - speed])
 
     def get_brightness(self, profile: int) -> int:
         raise NotImplementedError

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -554,10 +554,10 @@ class MainWindow(Adw.ApplicationWindow):
         self._debounce_row = None
         if caps.has_debounce:
             lo, hi = caps.debounce_range
-            self._debounce_row = Adw.SpinRow.new_with_range(lo, hi, 1)
-            self._debounce_row.set_title('Debounce')
-            self._debounce_row.set_subtitle(f'milliseconds ({lo} – {hi})')
-            global_group.add(self._debounce_row)
+            row, self._debounce_row = self._make_slider_row(
+                'Debounce', f'milliseconds ({lo} – {hi})', lo, hi, 1,
+                format_value=lambda v: f'{int(v)} ms')
+            global_group.add(row)
 
         # Angle snap
         self._angle_row = None
@@ -599,14 +599,16 @@ class MainWindow(Adw.ApplicationWindow):
             )
             profile_group.add(self._lod_row)
 
-        # LED brightness
+        # LED brightness - shown/edited as 0-100%, converted to the
+        # device's raw brightness_range (usually 0-255) at apply/reload
+        # time (see _apply()/_populate_profile()) so the on-wire value and
+        # the on-screen value don't have to match.
         self._bright_row = None
         if caps.has_led:
-            lo, hi = caps.brightness_range
-            self._bright_row = Adw.SpinRow.new_with_range(lo, hi, 5)
-            self._bright_row.set_title('LED Brightness')
-            self._bright_row.set_subtitle(f'{lo} – {hi}')
-            profile_group.add(self._bright_row)
+            row, self._bright_row = self._make_slider_row(
+                'LED Brightness', '0% – 100%', 0, 100, 5,
+                format_value=lambda v: f'{int(v)}%')
+            profile_group.add(row)
 
         # LED effect
         self._led_row = None
@@ -619,15 +621,20 @@ class MainWindow(Adw.ApplicationWindow):
             self._led_row.connect('notify::selected', self._on_led_changed)
             profile_group.add(self._led_row)
 
-        # Breath speed
+        # Breath speed - self._breath_row is the Gtk.Scale (get_value/
+        # set_value, as elsewhere), self._breath_row_container is the
+        # wrapping Adw.ActionRow (title + slider together) - the visibility
+        # toggle below needs to hide/show the whole row, not just the
+        # slider inside it.
         self._breath_row = None
+        self._breath_row_container = None
         if caps.has_led and caps.has_breath_speed:
             lo, hi = caps.breath_speed_range
-            self._breath_row = Adw.SpinRow.new_with_range(lo, hi, 1)
-            self._breath_row.set_title('Breath Speed')
-            self._breath_row.set_subtitle(f'{lo} – {hi}')
-            self._breath_row.set_visible(False)
-            profile_group.add(self._breath_row)
+            self._breath_row_container, self._breath_row = self._make_slider_row(
+                'Breath Speed', '', lo, hi, 1,
+                marks=[(lo, 'Slow'), (hi, 'Fast')])
+            self._breath_row_container.set_visible(False)
+            profile_group.add(self._breath_row_container)
 
         # ── DPI stages ───────────────────────────────────────────────────
         dpi_group = Adw.PreferencesGroup()
@@ -660,6 +667,31 @@ class MainWindow(Adw.ApplicationWindow):
                 self._color_buttons.append(color_btn)
             dpi_group.add(row)
             self._dpi_rows.append(row)
+
+        # ── Power Management ─────────────────────────────────────────────
+        self._power_saving_row = None
+        self._low_power_row = None
+        device = self._device
+        if hasattr(device, 'set_power_saving_timeout') or hasattr(device, 'set_low_power_threshold'):
+            power_group = Adw.PreferencesGroup()
+            power_group.set_title('Power Management')
+            power_group.set_description('Wireless power-saving behaviour')
+            page_box.append(power_group)
+
+            if hasattr(device, 'set_power_saving_timeout'):
+                row, self._power_saving_row = self._make_slider_row(
+                    'Wireless Power Saving',
+                    'Inactivity before the mouse sleeps (30 sec – 15 min)',
+                    30, 900, 30,
+                    format_value=lambda v: f'{int(v) // 60}:{int(v) % 60:02d}')
+                power_group.add(row)
+
+            if hasattr(device, 'set_low_power_threshold'):
+                row, self._low_power_row = self._make_slider_row(
+                    'Low Power Mode',
+                    'Battery percentage that triggers low power mode (0 – 100)',
+                    0, 100, 5)
+                power_group.add(row)
 
         # ── Button bindings (read-only display) ──────────────────────────
         btn_group = Adw.PreferencesGroup()
@@ -696,60 +728,52 @@ class MainWindow(Adw.ApplicationWindow):
         test_row.connect('activated', self._on_test_clicked)
         test_group.add(test_row)
 
-        # ── OS / Desktop Settings ────────────────────────────────────────
-        os_group = Adw.PreferencesGroup()
-        os_group.set_title('Desktop Mouse Settings')
-        os_group.set_description('System-wide GNOME settings (affects all mice)')
-        page_box.append(os_group)
+    def _make_slider_row(self, title, subtitle, lo, hi, step,
+                         format_value=None, marks=None):
+        """An Adw.ActionRow with a real Gtk.Scale slider as its suffix,
+        rather than a SpinRow's +/- stepper. Gtk.Scale (a Gtk.Range
+        subclass) already has the same get_value()/set_value() API a
+        SpinRow does, so callers can use the returned scale exactly like
+        the SpinRow fields elsewhere in this file - no other code needs
+        to know the difference.
 
-        self._accel_row = Adw.ComboRow()
-        self._accel_row.set_title('Acceleration Profile')
-        self._accel_row.set_subtitle('Use "Flat" for raw input (recommended for gaming)')
-        self._accel_row.set_model(Gtk.StringList.new(['Flat (raw)', 'Adaptive (default)']))
-        self._accel_row.connect('notify::selected', self._on_accel_changed)
-        os_group.add(self._accel_row)
-
-        adj_speed = Gtk.Adjustment(lower=-1.0, upper=1.0, step_increment=0.05,
-                                   page_increment=0.1)
-        self._speed_row = Adw.SpinRow(adjustment=adj_speed, digits=2)
-        self._speed_row.set_title('Pointer Speed')
-        self._speed_row.set_subtitle('Multiplier from -1.0 (slow) to 1.0 (fast), 0 = no change')
-        os_group.add(self._speed_row)
-
-        speed_apply = Adw.ButtonRow()
-        speed_apply.set_title('Apply Desktop Settings')
-        speed_apply.connect('activated', self._on_os_apply)
-        os_group.add(speed_apply)
-
-        self._load_os_settings()
-
-    def _load_os_settings(self):
-        try:
-            import subprocess
-            accel = subprocess.check_output(
-                ['gsettings', 'get', 'org.gnome.desktop.peripherals.mouse', 'accel-profile'],
-                text=True).strip().strip("'")
-            speed = subprocess.check_output(
-                ['gsettings', 'get', 'org.gnome.desktop.peripherals.mouse', 'speed'],
-                text=True).strip()
-            self._building = True
-            self._accel_row.set_selected(0 if accel == 'flat' else 1)
-            self._speed_row.set_value(float(speed))
-            self._building = False
-        except Exception:
-            pass
-
-    def _on_accel_changed(self, combo, _param):
-        pass  # applied via button
-
-    def _on_os_apply(self, _row):
-        accel = 'flat' if self._accel_row.get_selected() == 0 else 'adaptive'
-        speed = self._speed_row.get_value()
-        import subprocess
-        subprocess.run(['gsettings', 'set', 'org.gnome.desktop.peripherals.mouse',
-                        'accel-profile', accel])
-        subprocess.run(['gsettings', 'set', 'org.gnome.desktop.peripherals.mouse',
-                        'speed', str(speed)])
+        `format_value(value) -> str`, if given, replaces the plain numeric
+        readout (e.g. seconds -> "4:30", a raw 0-255 brightness -> "62%").
+        `marks`, if given, is a list of (value, label) endpoint captions
+        drawn below the trough (e.g. [(0, 'Slow'), (100, 'Fast')]) -
+        these are direction cues alongside the numeric readout, not a
+        replacement for it.
+        """
+        row = Adw.ActionRow()
+        row.set_title(title)
+        row.set_subtitle(subtitle)
+        adj = Gtk.Adjustment(lower=lo, upper=hi, step_increment=step,
+                             page_increment=step * 2)
+        scale = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL, adjustment=adj)
+        scale.set_valign(Gtk.Align.CENTER)
+        scale.set_hexpand(True)
+        scale.set_size_request(180, -1)
+        for mark_value, label in (marks or []):
+            scale.add_mark(mark_value, Gtk.PositionType.BOTTOM, label)
+        if format_value is not None:
+            # GtkScale's own "format-value" is a C-only vfunc, not
+            # connectable as a signal in this GI binding (raises
+            # "unknown signal name" at runtime) - a plain label kept in
+            # sync via the standard value-changed signal works everywhere.
+            scale.set_draw_value(False)
+            value_label = Gtk.Label(label=format_value(adj.get_value()))
+            value_label.set_valign(Gtk.Align.CENTER)
+            value_label.set_width_chars(5)
+            scale.connect('value-changed',
+                          lambda s: value_label.set_label(format_value(s.get_value())))
+            row.add_suffix(scale)
+            row.add_suffix(value_label)
+        else:
+            scale.set_digits(0)
+            scale.set_draw_value(True)
+            scale.set_value_pos(Gtk.PositionType.RIGHT)
+            row.add_suffix(scale)
+        return row, scale
 
     # ── UI event handlers ────────────────────────────────────────────────
 
@@ -767,10 +791,16 @@ class MainWindow(Adw.ApplicationWindow):
         if self._building:
             return
         caps = self._caps
-        if caps and self._breath_row:
+        if caps and self._breath_row_container:
             effects = caps.led_effects
             selected = effects[combo.get_selected()] if combo.get_selected() < len(effects) else ''
-            self._breath_row.set_visible(selected == 'breath')
+            # The pulsing/breathing effect is always the last entry in
+            # led_effects, by convention of every driver in this codebase
+            # (['off', 'steady', <that one>]) - checked this way rather
+            # than a hardcoded name since drivers differ on what to call
+            # it (feinmann8k.py: 'pulse', base.py's shared default and
+            # other drivers: 'breath').
+            self._breath_row_container.set_visible(selected == effects[-1])
 
     def _on_stage_count_changed(self, row, _param):
         if self._building:
@@ -828,10 +858,16 @@ class MainWindow(Adw.ApplicationWindow):
             s['ripple'] = self._ripple_row.get_active()
         if self._motion_row:
             s['motion'] = self._motion_row.get_active()
+        if self._power_saving_row:
+            s['power_saving'] = int(self._power_saving_row.get_value())
+        if self._low_power_row:
+            s['low_power'] = int(self._low_power_row.get_value())
         if self._lod_row:
             s['lod'] = caps.lod_values[self._lod_row.get_selected()]
         if self._bright_row:
-            s['brightness'] = int(self._bright_row.get_value())
+            lo, hi = caps.brightness_range
+            pct = self._bright_row.get_value()
+            s['brightness'] = round(lo + pct / 100 * (hi - lo))
         if self._led_row:
             s['led'] = caps.led_effects[self._led_row.get_selected()]
         if self._breath_row:
@@ -888,7 +924,12 @@ class MainWindow(Adw.ApplicationWindow):
         angle = self._read_field(device.get_angle_snap) if caps.has_angle_snap else None
         ripple = self._read_field(device.get_ripple_control) if caps.has_ripple_control else None
         motion = self._read_field(device.get_motion_sync) if caps.has_motion_sync else None
-        GLib.idle_add(self._populate_global, poll_hz, debounce, angle, ripple, motion)
+        power_saving = (self._read_field(device.get_power_saving_timeout)
+                        if hasattr(device, 'get_power_saving_timeout') else None)
+        low_power = (self._read_field(device.get_low_power_threshold)
+                    if hasattr(device, 'get_low_power_threshold') else None)
+        GLib.idle_add(self._populate_global, poll_hz, debounce, angle, ripple, motion,
+                      power_saving, low_power)
         self._do_reload_profile_inner()
         self._close_dev()
 
@@ -958,6 +999,10 @@ class MainWindow(Adw.ApplicationWindow):
                 device.set_ripple_control(s['ripple'])
             if 'motion' in s:
                 device.set_motion_sync(s['motion'])
+            if 'power_saving' in s:
+                device.set_power_saving_timeout(s['power_saving'])
+            if 'low_power' in s:
+                device.set_low_power_threshold(s['low_power'])
 
             p = s['profile']
             if 'lod' in s:
@@ -966,7 +1011,9 @@ class MainWindow(Adw.ApplicationWindow):
                 device.set_brightness(s['brightness'], p)
             if 'led' in s:
                 device.set_led_effect(s['led'], p)
-                if s['led'] == 'breath' and 'breath' in s:
+                # See _on_led_changed()'s comment - the pulsing effect's
+                # name varies per driver, so check by position not string.
+                if s['led'] == caps.led_effects[-1] and 'breath' in s:
                     device.set_breath_speed(s['breath'], p)
 
             stages = s['dpi_values'][:s['num_stages']]
@@ -1001,7 +1048,8 @@ class MainWindow(Adw.ApplicationWindow):
 
     # ── UI population helpers ────────────────────────────────────────────
 
-    def _populate_global(self, poll_hz, debounce, angle, ripple, motion):
+    def _populate_global(self, poll_hz, debounce, angle, ripple, motion,
+                         power_saving=None, low_power=None):
         caps = self._caps
         self._building = True
         # Find index of polling rate
@@ -1018,6 +1066,10 @@ class MainWindow(Adw.ApplicationWindow):
             self._ripple_row.set_active(ripple)
         if self._motion_row and motion is not None:
             self._motion_row.set_active(motion)
+        if self._power_saving_row and power_saving is not None:
+            self._power_saving_row.set_value(power_saving)
+        if self._low_power_row and low_power is not None:
+            self._low_power_row.set_value(low_power)
         self._building = False
 
     def _populate_profile(self, lod, brightness, led, breath, dpi_info, colors, buttons):
@@ -1030,7 +1082,9 @@ class MainWindow(Adw.ApplicationWindow):
                 lod_idx = 0
             self._lod_row.set_selected(lod_idx)
         if self._bright_row and brightness is not None:
-            self._bright_row.set_value(brightness)
+            lo, hi = caps.brightness_range
+            pct = round((brightness - lo) / (hi - lo) * 100) if hi > lo else 0
+            self._bright_row.set_value(pct)
         if self._led_row and led is not None:
             try:
                 led_idx = caps.led_effects.index(led)
@@ -1039,8 +1093,8 @@ class MainWindow(Adw.ApplicationWindow):
             self._led_row.set_selected(led_idx)
         if self._breath_row and breath is not None:
             self._breath_row.set_value(breath)
-            if led:
-                self._breath_row.set_visible(led == 'breath')
+            if led and self._breath_row_container:
+                self._breath_row_container.set_visible(led == caps.led_effects[-1])
 
         stages = dpi_info['stages']
         num    = dpi_info['count']

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -15,6 +15,7 @@ The system-tray icon requires the GNOME AppIndicator extension:
 import sys
 import os
 import json
+import re
 import struct
 import threading
 import time
@@ -28,7 +29,11 @@ from gi.repository import Gtk, Adw, GLib, Gio, Gdk, Dbusmenu
 from pulsar_mouse import find_device, scan_devices, __version__
 from pulsar_mouse.base import PulsarDevice, DeviceCapabilities
 from pulsar_mouse.drivers import discover_all
-from pulsar_mouse.hid import describe_button
+from pulsar_mouse.hid import (
+    describe_button, parse_button_function,
+    MOUSE_ACTIONS, SCROLL_ACTIONS, DPI_ACTIONS, PROFILE_ACTIONS,
+    MEDIA_CODES, HID_MODS, HID_KEYS,
+)
 
 APP_ID = 'io.github.packerlschupfer.PulsarMouse'
 
@@ -56,6 +61,91 @@ def _connection_quality_label(pct):
     if pct >= 20:
         return 'Weak'
     return 'Poor'
+
+
+def _is_gnome_detected() -> bool:
+    """Whether GNOME is the running desktop - the org.gnome.desktop.
+    peripherals.mouse gsettings schema this app's OS-settings group reads/
+    writes only meaningfully affects cursor behaviour under GNOME (Mutter/
+    GNOME Shell), not other compositors like Hyprland/Sway, even though the
+    schema itself may still be technically settable elsewhere."""
+    desktop = (os.environ.get('XDG_CURRENT_DESKTOP', '') + ':' +
+              os.environ.get('DESKTOP_SESSION', '')).lower()
+    return 'gnome' in desktop
+
+
+def _is_hyprland_detected() -> bool:
+    """HYPRLAND_INSTANCE_SIGNATURE is set by Hyprland itself specifically
+    (unlike XDG_CURRENT_DESKTOP, which some other compositors also set to
+    misleading values) - it's the same variable hyprctl itself relies on
+    to find the right instance, so it's the most direct signal available."""
+    return bool(os.environ.get('HYPRLAND_INSTANCE_SIGNATURE'))
+
+
+def _is_kde_detected() -> bool:
+    """KDE_FULL_SESSION is set specifically by Plasma sessions; falls back
+    to XDG_CURRENT_DESKTOP for setups that only set that."""
+    if os.environ.get('KDE_FULL_SESSION'):
+        return True
+    desktop = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
+    return 'kde' in desktop or 'plasma' in desktop
+
+
+def _parse_svg_path(d: str) -> list[tuple]:
+    """Parse an SVG path 'd' string into Cairo-ready segments.
+
+    Only supports absolute M/L/C/Z commands with exactly one coordinate
+    set per command token (no implicit repeats, no relative m/l/c) -
+    that's the subset actual vector-editor exports (Illustrator/Figma/
+    Inkscape "Export As SVG") produce, and all InputTestDialog's traced
+    icon uses. Returns a list of ('move', x, y) / ('line', x, y) /
+    ('curve', x1,y1,x2,y2,x3,y3) / ('close',) tuples.
+    """
+    segments = []
+    for cmd, arg in re.findall(r'([MLCZ])([^MLCZ]*)', d):
+        nums = [float(n) for n in re.findall(r'-?\d+\.?\d*', arg)]
+        if cmd == 'M':
+            segments.append(('move', nums[0], nums[1]))
+        elif cmd == 'L':
+            segments.append(('line', nums[0], nums[1]))
+        elif cmd == 'C':
+            segments.append(('curve', *nums[:6]))
+        elif cmd == 'Z':
+            segments.append(('close',))
+    return segments
+
+
+def _svg_path_bbox(segments: list[tuple]) -> tuple[float, float, float, float]:
+    """(min_x, min_y, max_x, max_y) across every point in the segments,
+    including curve control points (not just endpoints) so a bulging
+    curve doesn't get clipped - slightly looser than the curve's true
+    tight bbox, which is fine for fitting a diagram into a widget."""
+    xs, ys = [], []
+    for seg in segments:
+        if seg[0] in ('move', 'line'):
+            xs.append(seg[1]); ys.append(seg[2])
+        elif seg[0] == 'curve':
+            xs += [seg[1], seg[3], seg[5]]
+            ys += [seg[2], seg[4], seg[6]]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def _draw_svg_path(cr, segments: list[tuple], tx: float, ty: float,
+                    sx: float, sy: float):
+    """Replay parsed segments as Cairo calls, mapping each SVG-space
+    point (x,y) to widget-space via (x*sx+tx, y*sy+ty)."""
+    for seg in segments:
+        if seg[0] == 'move':
+            cr.move_to(seg[1] * sx + tx, seg[2] * sy + ty)
+        elif seg[0] == 'line':
+            cr.line_to(seg[1] * sx + tx, seg[2] * sy + ty)
+        elif seg[0] == 'curve':
+            cr.curve_to(seg[1] * sx + tx, seg[2] * sy + ty,
+                        seg[3] * sx + tx, seg[4] * sy + ty,
+                        seg[5] * sx + tx, seg[6] * sy + ty)
+        elif seg[0] == 'close':
+            cr.close_path()
+
 
 _SNI_XML = """
 <node>
@@ -228,10 +318,17 @@ class PulsarMouseApp(Adw.Application):
         # own comment on this) - it only ever arrives via async hidraw
         # events, so unlike Battery this item stays "—" until the first one
         # shows up rather than being read up front.
+        #
+        # Gated on get_power (not find_hidraw): find_hidraw has a base-class
+        # default (returns None) so hasattr() on it is true for every
+        # driver, wired or wireless - it doesn't actually indicate this
+        # device can report signal strength. get_power only exists on
+        # wireless drivers, and RF signal quality is meaningless for a
+        # wired connection anyway.
         self._conn_item = None
-        if hasattr(device, 'find_hidraw'):
+        if hasattr(device, 'get_power'):
             conn_item = Dbusmenu.Menuitem.new()
-            conn_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Connection Quality: —')
+            conn_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Signal: —')
             try:
                 conn_item.property_set_bool(Dbusmenu.MENUITEM_PROP_ENABLED, False)
             except Exception:
@@ -358,7 +455,7 @@ class PulsarMouseApp(Adw.Application):
         self._update_tray_tooltip()
 
     def _set_conn_quality_label(self, pct):
-        self._conn_text = f'Connection Quality: {pct}%  —  {_connection_quality_label(pct)}'
+        self._conn_text = f'Signal: {pct}% ({_connection_quality_label(pct)})'
         if self._conn_item is not None:
             self._conn_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, self._conn_text)
         self._update_tray_tooltip()
@@ -494,6 +591,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._build_ui()
         GLib.idle_add(self._reload)
         GLib.idle_add(self._start_home_updates)
+        GLib.idle_add(self._refresh_firmware_version)
 
     def _build_ui(self):
         caps = self._caps
@@ -641,6 +739,12 @@ class MainWindow(Adw.ApplicationWindow):
         called once from __init__ after the window itself exists.
         """
         caps = self._caps
+        device = self._device
+        # get_power only exists on wireless drivers - unlike find_hidraw,
+        # which has a base-class default (returns None) that makes
+        # hasattr() on it true for every driver, wired or wireless.
+        is_wireless = hasattr(device, 'get_power')
+
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         box.set_valign(Gtk.Align.START)
         box.set_margin_top(48)
@@ -662,10 +766,23 @@ class MainWindow(Adw.ApplicationWindow):
         status_group.set_margin_top(24)
         box.append(status_group)
 
+        model_row = Adw.ActionRow()
+        model_row.set_title('Model')
+        model_row.set_subtitle(caps.name)
+        model_row.add_prefix(Gtk.Image.new_from_icon_name('input-mouse-symbolic'))
+        status_group.add(model_row)
+
+        self._firmware_row = Adw.ActionRow()
+        self._firmware_row.set_title('Firmware Version')
+        self._firmware_row.set_subtitle('—')
+        self._firmware_row.add_prefix(Gtk.Image.new_from_icon_name('application-x-firmware-symbolic'))
+        status_group.add(self._firmware_row)
+
         conn_row = Adw.ActionRow()
         conn_row.set_title('Connection')
-        conn_row.set_subtitle('Wireless')
-        conn_row.add_prefix(Gtk.Image.new_from_icon_name('network-wireless-symbolic'))
+        conn_row.set_subtitle('Wireless' if is_wireless else 'Wired')
+        conn_row.add_prefix(Gtk.Image.new_from_icon_name(
+            'network-wireless-symbolic' if is_wireless else 'network-wired-symbolic'))
         connected_label = Gtk.Label(label='Connected')
         connected_label.add_css_class('success')
         conn_row.add_suffix(connected_label)
@@ -676,33 +793,43 @@ class MainWindow(Adw.ApplicationWindow):
         # finishes) - not event-driven, since polling rate only ever
         # changes via this app, not something the device pushes on its own.
         self._home_mode_row = Adw.ActionRow()
-        self._home_mode_row.set_title('Wireless Mode')
+        self._home_mode_row.set_title('Polling Rate')
         self._home_mode_row.set_subtitle('—')
         self._home_mode_row.add_prefix(
             Gtk.Image.new_from_icon_name('network-wireless-symbolic'))
         status_group.add(self._home_mode_row)
 
-        # Always shown even though we can't know in advance whether this
-        # model actually pushes signal-quality events - it just stays
-        # "—" harmlessly if nothing ever arrives (see
-        # _home_hidraw_listener()).
-        self._home_signal_row = Adw.ActionRow()
-        self._home_signal_row.set_title('Connection Quality')
-        self._home_signal_row.set_subtitle('—')
-        self._home_signal_row.add_prefix(
-            Gtk.Image.new_from_icon_name('network-wireless-signal-good-symbolic'))
-        status_group.add(self._home_signal_row)
+        # DPI, kept in sync the same way as Polling Rate above:
+        # _populate_profile() (on reload) and _apply() (immediately on
+        # Apply, before the write even finishes).
+        self._home_dpi_row = Adw.ActionRow()
+        self._home_dpi_row.set_title('DPI')
+        self._home_dpi_row.set_subtitle('—')
+        self._home_dpi_row.add_prefix(
+            Gtk.Image.new_from_icon_name('zoom-in-symbolic'))
+        status_group.add(self._home_dpi_row)
 
-        device = self._device
-        if hasattr(device, 'get_power'):
+        # Battery and RF signal quality are both meaningless for a wired
+        # mouse, so both rows are gated on is_wireless (mirrored in the
+        # tray's _build_tray() for its own Battery/Connection Quality menu
+        # items).
+        self._home_signal_row = None
+        if is_wireless:
+            self._home_signal_row = Adw.ActionRow()
+            self._home_signal_row.set_title('Connection Quality')
+            self._home_signal_row.set_subtitle('—')
+            self._home_signal_row.add_prefix(
+                Gtk.Image.new_from_icon_name('network-wireless-signal-good-symbolic'))
+            status_group.add(self._home_signal_row)
+
+        self._home_battery_row = None
+        if is_wireless:
             self._home_battery_row = Adw.ActionRow()
             self._home_battery_row.set_title('Battery')
             self._home_battery_row.set_subtitle('—')
             self._home_battery_row.add_prefix(
                 Gtk.Image.new_from_icon_name('battery-good-symbolic'))
             status_group.add(self._home_battery_row)
-        else:
-            self._home_battery_row = None
 
         return box
 
@@ -715,10 +842,16 @@ class MainWindow(Adw.ApplicationWindow):
 
         self._poll_row = Adw.ComboRow()
         self._poll_row.set_title('Polling Rate')
-        self._poll_row.set_subtitle('Hz')
         self._poll_row.set_model(
             Gtk.StringList.new([f'{hz} Hz' for hz in caps.polling_rates])
         )
+        self._poll_row.set_tooltip_text(
+            '1000Hz: Balanced latency and battery life; stable on all PCs.\n'
+            '4000Hz / 8000Hz: Smooth tracking and lowest latency; drains '
+            'battery fast.\n\n'
+            'A high polling rate requires a high-end CPU to prevent '
+            'stutters. On Linux, 8000Hz may cause severe lag in non-native '
+            '(Proton/Wine) games.')
         global_group.add(self._poll_row)
 
         self._debounce_row = None
@@ -727,6 +860,12 @@ class MainWindow(Adw.ApplicationWindow):
             row, self._debounce_row = self._make_slider_row(
                 'Debounce', f'milliseconds ({lo} – {hi})', lo, hi, 1,
                 format_value=lambda v: f'{int(v)} ms')
+            row.set_tooltip_text(
+                'Adjusts the delay buffer (in ms) to prevent accidental '
+                'double-clicks or slam-clicks.\n\n'
+                'Lower (0-2ms): Fastest response time; best for Optical switches.\n'
+                'Higher (3-5ms+): Eliminates chatter or accidental clicks; '
+                'required for older Mechanical switches.')
             global_group.add(row)
 
         self._angle_row = None
@@ -734,6 +873,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._angle_row = Adw.SwitchRow()
             self._angle_row.set_title('Angle Snap')
             self._angle_row.set_subtitle('Straightens cursor movement to horizontal/vertical lines')
+            self._angle_row.set_tooltip_text('May add latency, not recommended for gaming')
             global_group.add(self._angle_row)
 
         self._ripple_row = None
@@ -741,13 +881,18 @@ class MainWindow(Adw.ApplicationWindow):
             self._ripple_row = Adw.SwitchRow()
             self._ripple_row.set_title('Ripple Control')
             self._ripple_row.set_subtitle('Smooths out sensor jitter at low speeds')
+            self._ripple_row.set_tooltip_text('May add latency, not recommended for gaming')
             global_group.add(self._ripple_row)
 
         self._motion_row = None
         if caps.has_motion_sync:
             self._motion_row = Adw.SwitchRow()
             self._motion_row.set_title('Motion Sync')
-            self._motion_row.set_subtitle('Synchronises sensor data with USB polling interval')
+            self._motion_row.set_subtitle('Synchronises sensor reads with USB polling (Recommended)')
+            self._motion_row.set_tooltip_text(
+                'Great for tracking smoothness at 1000Hz, but should be '
+                'disabled if you run at 8K polling rate to guarantee the '
+                'lowest possible latency')
             global_group.add(self._motion_row)
 
         # LOD lives here (not on the Customize tab with the rest of
@@ -757,7 +902,18 @@ class MainWindow(Adw.ApplicationWindow):
         tracking_group.set_title('Tracking')
 
         self._lod_row = None
-        if caps.lod_values:
+        if caps.lod_values and caps.lod_step:
+            lo, hi = caps.lod_values[0], caps.lod_values[-1]
+            row, self._lod_row = self._make_slider_row(
+                'Lift-off Distance', 'Height at which tracking stops when lifting the mouse',
+                lo, hi, caps.lod_step, format_value=lambda v: f'{v:.1f} mm')
+            row.set_tooltip_text(
+                'Lower (0.7-1.0mm): Prevents unwanted cursor drift when '
+                'resetting your mouse; ideal for low-sensitivity gaming.\n\n'
+                'Higher (1.5-2.0mm): Prevents sensor skipping on textured '
+                'pads or when using thick aftermarket skates.')
+            tracking_group.add(row)
+        elif caps.lod_values:
             self._lod_row = Adw.ComboRow()
             self._lod_row.set_title('Lift-off Distance')
             self._lod_row.set_subtitle('Height at which tracking stops when lifting the mouse')
@@ -800,7 +956,217 @@ class MainWindow(Adw.ApplicationWindow):
         if caps.lod_values:
             groups.append(tracking_group)
         groups.append(dpi_group)
+
+        self._accel_row = None
+        self._speed_row = None
+        if _is_gnome_detected():
+            os_group = Adw.PreferencesGroup()
+            os_group.set_title('Desktop Mouse Settings')
+            os_group.set_description('System-wide GNOME settings (affects all mice)')
+
+            self._accel_row = Adw.ComboRow()
+            self._accel_row.set_title('Acceleration Profile')
+            self._accel_row.set_subtitle('Use "Flat" for raw input (recommended for gaming)')
+            self._accel_row.set_model(Gtk.StringList.new(['Flat (raw)', 'Adaptive (default)']))
+            os_group.add(self._accel_row)
+
+            adj_speed = Gtk.Adjustment(lower=-1.0, upper=1.0, step_increment=0.05,
+                                       page_increment=0.1)
+            self._speed_row = Adw.SpinRow(adjustment=adj_speed, digits=2)
+            self._speed_row.set_title('Pointer Speed')
+            self._speed_row.set_subtitle('Multiplier from -1.0 (slow) to 1.0 (fast), 0 = no change')
+            os_group.add(self._speed_row)
+
+            speed_apply = Adw.ButtonRow()
+            speed_apply.set_title('Apply Desktop Settings')
+            speed_apply.connect('activated', self._on_os_apply)
+            os_group.add(speed_apply)
+
+            groups.append(os_group)
+            self._load_os_settings()
+
+        self._hypr_accel_row = None
+        self._hypr_speed_row = None
+        if _is_hyprland_detected():
+            hypr_group = Adw.PreferencesGroup()
+            hypr_group.set_title('Hyprland Mouse Settings')
+
+            self._hypr_accel_row = Adw.ComboRow()
+            self._hypr_accel_row.set_title('Acceleration Profile')
+            self._hypr_accel_row.set_subtitle('Use "Flat" for raw input (recommended for gaming)')
+            self._hypr_accel_row.set_model(Gtk.StringList.new(['Flat (raw)', 'Adaptive (default)']))
+            hypr_group.add(self._hypr_accel_row)
+
+            adj_hypr_speed = Gtk.Adjustment(lower=-1.0, upper=1.0, step_increment=0.05,
+                                            page_increment=0.1)
+            self._hypr_speed_row = Adw.SpinRow(adjustment=adj_hypr_speed, digits=2)
+            self._hypr_speed_row.set_title('Sensitivity')
+            self._hypr_speed_row.set_subtitle('Multiplier from -1.0 (slow) to 1.0 (fast), 0 = no change')
+            hypr_group.add(self._hypr_speed_row)
+
+            hypr_apply = Adw.ButtonRow()
+            hypr_apply.set_title('Apply Hyprland Settings')
+            hypr_apply.set_tooltip_text(
+                f'Applied live via hyprctl, and written to {self._HYPR_CONF_PATH} '
+                'so it persists - add "source = ~/.config/hypr/'
+                'pulsar-mouse-input.conf" to your hyprland.conf once so it '
+                'takes effect on restart too')
+            hypr_apply.connect('activated', self._on_hypr_apply)
+            hypr_group.add(hypr_apply)
+
+            groups.append(hypr_group)
+            self._load_hypr_settings()
+
+        self._kde_accel_row = None
+        self._kde_speed_row = None
+        if _is_kde_detected():
+            kde_group = Adw.PreferencesGroup()
+            kde_group.set_title('KDE Plasma Mouse Settings')
+            kde_group.set_description(
+                'Written to kcminputrc - persists across restarts, but '
+                'requires kwriteconfig5/6 to be installed')
+
+            self._kde_accel_row = Adw.ComboRow()
+            self._kde_accel_row.set_title('Acceleration Profile')
+            self._kde_accel_row.set_subtitle('Use "Flat" for raw input (recommended for gaming)')
+            self._kde_accel_row.set_model(Gtk.StringList.new(['Flat (raw)', 'Adaptive (default)']))
+            kde_group.add(self._kde_accel_row)
+
+            adj_kde_speed = Gtk.Adjustment(lower=-1.0, upper=1.0, step_increment=0.05,
+                                           page_increment=0.1)
+            self._kde_speed_row = Adw.SpinRow(adjustment=adj_kde_speed, digits=2)
+            self._kde_speed_row.set_title('Pointer Acceleration')
+            self._kde_speed_row.set_subtitle('Multiplier from -1.0 (slow) to 1.0 (fast), 0 = no change')
+            kde_group.add(self._kde_speed_row)
+
+            kde_apply = Adw.ButtonRow()
+            kde_apply.set_title('Apply KDE Settings')
+            kde_apply.connect('activated', self._on_kde_apply)
+            kde_group.add(kde_apply)
+
+            groups.append(kde_group)
+            self._load_kde_settings()
+
         return self._wrap_page(*groups)
+
+    def _load_os_settings(self):
+        import subprocess
+        try:
+            accel = subprocess.check_output(
+                ['gsettings', 'get', 'org.gnome.desktop.peripherals.mouse', 'accel-profile'],
+                text=True).strip().strip("'")
+            speed = subprocess.check_output(
+                ['gsettings', 'get', 'org.gnome.desktop.peripherals.mouse', 'speed'],
+                text=True).strip()
+            self._building = True
+            self._accel_row.set_selected(0 if accel == 'flat' else 1)
+            self._speed_row.set_value(float(speed))
+            self._building = False
+        except Exception:
+            pass
+
+    def _on_os_apply(self, _row):
+        import subprocess
+        accel = 'flat' if self._accel_row.get_selected() == 0 else 'adaptive'
+        speed = self._speed_row.get_value()
+        try:
+            subprocess.run(['gsettings', 'set', 'org.gnome.desktop.peripherals.mouse',
+                            'accel-profile', accel], check=True)
+            subprocess.run(['gsettings', 'set', 'org.gnome.desktop.peripherals.mouse',
+                            'speed', str(speed)], check=True)
+            self._show_toast('Desktop settings applied')
+        except Exception as e:
+            self._show_error(f'Could not apply desktop settings: {e}')
+
+    # Dedicated snippet file rather than editing hyprland.conf directly -
+    # that file's structure varies too much per user (multiple `input {}`
+    # blocks, source-split configs, comments) to safely locate-and-patch
+    # without risking corrupting something we don't understand. Requires a
+    # one-time `source = ~/.config/hypr/pulsar-mouse-input.conf` line in
+    # the user's own hyprland.conf, same pattern many other Hyprland addon
+    # tools use for the same reason.
+    _HYPR_CONF_PATH = os.path.expanduser('~/.config/hypr/pulsar-mouse-input.conf')
+
+    def _load_hypr_settings(self):
+        import subprocess, json
+        try:
+            accel_raw = json.loads(subprocess.check_output(
+                ['hyprctl', 'getoption', 'input:accel_profile', '-j'], text=True))
+            speed_raw = json.loads(subprocess.check_output(
+                ['hyprctl', 'getoption', 'input:sensitivity', '-j'], text=True))
+            accel = accel_raw.get('str', 'adaptive')
+            speed = speed_raw.get('float', 0.0)
+            self._building = True
+            self._hypr_accel_row.set_selected(0 if accel == 'flat' else 1)
+            self._hypr_speed_row.set_value(speed)
+            self._building = False
+        except Exception:
+            pass
+
+    def _on_hypr_apply(self, _row):
+        import subprocess
+        accel = 'flat' if self._hypr_accel_row.get_selected() == 0 else 'adaptive'
+        speed = self._hypr_speed_row.get_value()
+        try:
+            # Live effect, immediately - runtime-only, hence also writing
+            # the snippet file below for the setting to survive a restart.
+            subprocess.run(['hyprctl', 'keyword', 'input:accel_profile', accel], check=True)
+            subprocess.run(['hyprctl', 'keyword', 'input:sensitivity', f'{speed:.6f}'], check=True)
+            with open(self._HYPR_CONF_PATH, 'w') as f:
+                f.write(
+                    'input {\n'
+                    f'    sensitivity = {speed:.6f}    # Range: -1.0 to 1.0 (0 = default)\n'
+                    f'    accel_profile = {accel} # Optional: removes mouse acceleration ("flat" or "adaptive")\n'
+                    '}\n'
+                )
+            self._show_toast('Hyprland settings applied')
+        except Exception as e:
+            self._show_error(f'Could not apply Hyprland settings: {e}')
+
+    def _load_kde_settings(self):
+        import subprocess, shutil
+        reader = shutil.which('kreadconfig6') or shutil.which('kreadconfig5')
+        if reader is None:
+            return
+        try:
+            flat = subprocess.check_output(
+                [reader, '--file', 'kcminputrc', '--group', 'Mouse',
+                 '--key', 'XLbInptAccelProfileFlat', '--default', 'false'],
+                text=True).strip()
+            speed = subprocess.check_output(
+                [reader, '--file', 'kcminputrc', '--group', 'Mouse',
+                 '--key', 'XLbInptPointerAcceleration', '--default', '0.0'],
+                text=True).strip()
+            self._building = True
+            self._kde_accel_row.set_selected(0 if flat == 'true' else 1)
+            self._kde_speed_row.set_value(float(speed))
+            self._building = False
+        except Exception:
+            pass
+
+    def _on_kde_apply(self, _row):
+        import subprocess, shutil
+        writer = shutil.which('kwriteconfig6') or shutil.which('kwriteconfig5')
+        if writer is None:
+            self._show_error('kwriteconfig5/6 not found - cannot write KDE settings')
+            return
+        flat = 'true' if self._kde_accel_row.get_selected() == 0 else 'false'
+        speed = self._kde_speed_row.get_value()
+        try:
+            subprocess.run([writer, '--file', 'kcminputrc', '--group', 'Mouse',
+                            '--key', 'XLbInptAccelProfileFlat', flat], check=True)
+            subprocess.run([writer, '--file', 'kcminputrc', '--group', 'Mouse',
+                            '--key', 'XLbInptPointerAcceleration', str(speed)], check=True)
+            # Best-effort live reload - harmless no-op if kwin isn't the
+            # compositor or the dbus call isn't available; the config file
+            # write above is what actually matters for persistence.
+            for qdbus in ('qdbus6', 'qdbus'):
+                if shutil.which(qdbus):
+                    subprocess.run([qdbus, 'org.kde.KWin', '/KWin', 'reconfigure'])
+                    break
+            self._show_toast('KDE settings applied')
+        except Exception as e:
+            self._show_error(f'Could not apply KDE settings: {e}')
 
     def _build_customize_page(self):
         caps = self._caps
@@ -815,7 +1181,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._bright_row = None
         if caps.has_led:
             row, self._bright_row = self._make_slider_row(
-                'LED Brightness', '0% – 100%', 0, 100, 5,
+                'LED Brightness', '', 0, 100, 5,
                 format_value=lambda v: f'{int(v)}%')
             led_group.add(row)
 
@@ -841,12 +1207,13 @@ class MainWindow(Adw.ApplicationWindow):
             self._breath_row_container, self._breath_row = self._make_slider_row(
                 'Pulse Speed', '', lo, hi, 1,
                 marks=[(lo, 'Slow'), (hi, 'Fast')])
+            self._breath_row.set_draw_value(False)
             self._breath_row_container.set_visible(False)
             led_group.add(self._breath_row_container)
 
         btn_group = Adw.PreferencesGroup()
         btn_group.set_title('Button Bindings')
-        btn_group.set_description('Use the CLI (--button) to remap buttons')
+        btn_group.set_description('Click a button to remap it')
 
         self._btn_rows = {}
         for btn_name, btn_id in caps.buttons.items():
@@ -854,6 +1221,9 @@ class MainWindow(Adw.ApplicationWindow):
             label = caps.button_labels.get(btn_name, btn_name.capitalize())
             row.set_title(label)
             row.set_subtitle('–')
+            row.set_activatable(True)
+            row.add_suffix(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+            row.connect('activated', self._on_button_row_activated, btn_id, label)
             btn_group.add(row)
             self._btn_rows[btn_id] = row
 
@@ -946,15 +1316,15 @@ X-GNOME-Autostart-enabled=true
                 row, self._power_saving_row = self._make_slider_row(
                     'Wireless Power Saving',
                     'Inactivity before the mouse sleeps (30 sec – 15 min)',
-                    30, 900, 30,
+                    30, 900, 30, snap=True,
                     format_value=lambda v: f'{int(v) // 60}:{int(v) % 60:02d}')
                 power_group.add(row)
 
             if hasattr(device, 'set_low_power_threshold'):
                 row, self._low_power_row = self._make_slider_row(
                     'Low Power Mode',
-                    'Battery percentage that triggers low power mode (0 – 100)',
-                    0, 100, 5)
+                    'Battery percentage that triggers low power mode',
+                    0, 100, 5, snap=True)
                 power_group.add(row)
 
             groups.append(power_group)
@@ -1006,9 +1376,33 @@ X-GNOME-Autostart-enabled=true
         charging = '  (charging)' if pwr['power_connected'] else ''
         self._home_battery_row.set_subtitle(f'{pct}%{charging}')
 
-    def _home_hidraw_listener(self):
+    def _refresh_firmware_version(self):
         device = self._device
-        if device is None or not hasattr(device, 'find_hidraw'):
+        if device is None or self._firmware_row is None:
+            return
+
+        def _read():
+            try:
+                with _USB_LOCK:
+                    device.open()
+                    try:
+                        fw = device.get_firmware_version()
+                    finally:
+                        device.close()
+                if fw != 'unknown':
+                    GLib.idle_add(self._firmware_row.set_subtitle, fw)
+            except Exception:
+                pass
+        threading.Thread(target=_read, daemon=True).start()
+
+    def _home_hidraw_listener(self):
+        # Only ever acts on signal_percent events (unlike the tray's own
+        # _hidraw_listener, which also handles DPI) - gated on get_power,
+        # not find_hidraw, for the same reason as _home_signal_row's
+        # construction above: find_hidraw's base-class default makes
+        # hasattr() on it true for every driver, wired or wireless.
+        device = self._device
+        if device is None or self._home_signal_row is None:
             return
         path = device.find_hidraw()
         if not path:
@@ -1035,10 +1429,12 @@ X-GNOME-Autostart-enabled=true
             os.close(fd)
 
     def _set_home_signal(self, pct):
+        if self._home_signal_row is None:
+            return
         self._home_signal_row.set_subtitle(f'{pct}%  —  {_connection_quality_label(pct)}')
 
     def _make_slider_row(self, title, subtitle, lo, hi, step,
-                         format_value=None, marks=None):
+                         format_value=None, marks=None, snap=False):
         """An Adw.ActionRow with a real Gtk.Scale slider as its suffix,
         rather than a SpinRow's +/- stepper. Gtk.Scale (a Gtk.Range
         subclass) already has the same get_value()/set_value() API a
@@ -1051,7 +1447,11 @@ X-GNOME-Autostart-enabled=true
         `marks`, if given, is a list of (value, label) endpoint captions
         drawn below the trough (e.g. [(0, 'Slow'), (100, 'Fast')]) -
         these are direction cues alongside the numeric readout, not a
-        replacement for it.
+        replacement for it. `snap`, if True, rounds the value to the
+        nearest multiple of `step` (relative to `lo`) as the user drags -
+        step_increment on its own only affects keyboard/scroll-wheel
+        nudges, not mouse-drag positioning, which GtkRange otherwise
+        computes continuously from pointer position.
         """
         row = Adw.ActionRow()
         row.set_title(title)
@@ -1064,6 +1464,21 @@ X-GNOME-Autostart-enabled=true
         scale.set_size_request(180, -1)
         for mark_value, label in (marks or []):
             scale.add_mark(mark_value, Gtk.PositionType.BOTTOM, label)
+        if snap:
+            def _snap(s, _step=step, _lo=lo):
+                # Skip while populating from a real device read (see
+                # _populate_global()'s self._building guard) - the stored
+                # value on real hardware isn't guaranteed to already be a
+                # step multiple (seen e.g. 297s power-saving, not a
+                # multiple of 30), and snapping it here would silently
+                # change what the next Apply writes back to the device
+                # without the user ever touching this slider.
+                if self._building:
+                    return
+                snapped = _lo + round((s.get_value() - _lo) / _step) * _step
+                if snapped != s.get_value():
+                    s.set_value(snapped)
+            scale.connect('value-changed', _snap)
         if format_value is not None:
             # GtkScale's own "format-value" is a C-only vfunc, not
             # connectable as a signal in this GI binding (raises
@@ -1089,6 +1504,26 @@ X-GNOME-Autostart-enabled=true
     def _on_test_clicked(self, _row):
         dialog = InputTestDialog(transient_for=self, device=self._device)
         dialog.present()
+
+    def _on_button_row_activated(self, _row, btn_id, label):
+        current = self._btn_rows[btn_id].get_subtitle()
+        dialog = RemapButtonDialog(
+            transient_for=self, btn_label=label, current_spec=current,
+            on_applied=lambda t, a1, a2: self._run_bg(
+                lambda: self._do_remap_button(btn_id, t, a1, a2)))
+        dialog.present()
+
+    def _do_remap_button(self, btn_id, btn_type, a1, a2):
+        if not self._open_dev():
+            return
+        try:
+            self._device.set_button(btn_id, btn_type, a1, a2, self._profile)
+            t, ra1, ra2 = self._device.get_button(btn_id, self._profile)
+            GLib.idle_add(self._btn_rows[btn_id].set_subtitle, describe_button(t, ra1, ra2))
+            GLib.idle_add(self._show_toast, 'Button remapped')
+        except Exception as e:
+            GLib.idle_add(self._show_error, f'Remap error: {e}')
+        self._close_dev()
 
     def _on_profile_changed(self, combo, _param):
         if self._building:
@@ -1236,6 +1671,8 @@ X-GNOME-Autostart-enabled=true
         }
         if self._home_mode_row is not None:
             self._home_mode_row.set_subtitle(f"{s['poll_hz']} Hz")
+        if self._home_dpi_row is not None:
+            self._home_dpi_row.set_subtitle(f"{s['dpi_values'][s['active'] - 1]} DPI")
         if self._debounce_row:
             s['debounce'] = int(self._debounce_row.get_value())
         if self._angle_row:
@@ -1249,7 +1686,10 @@ X-GNOME-Autostart-enabled=true
         if self._low_power_row:
             s['low_power'] = int(self._low_power_row.get_value())
         if self._lod_row:
-            s['lod'] = caps.lod_values[self._lod_row.get_selected()]
+            if caps.lod_step:
+                s['lod'] = round(self._lod_row.get_value(), 1)
+            else:
+                s['lod'] = caps.lod_values[self._lod_row.get_selected()]
         if self._bright_row:
             lo, hi = caps.brightness_range
             pct = self._bright_row.get_value()
@@ -1478,11 +1918,14 @@ X-GNOME-Autostart-enabled=true
         caps = self._caps
         self._building = True
         if self._lod_row and lod is not None:
-            try:
-                lod_idx = caps.lod_values.index(lod)
-            except ValueError:
-                lod_idx = 0
-            self._lod_row.set_selected(lod_idx)
+            if caps.lod_step:
+                self._lod_row.set_value(lod)
+            else:
+                try:
+                    lod_idx = caps.lod_values.index(lod)
+                except ValueError:
+                    lod_idx = 0
+                self._lod_row.set_selected(lod_idx)
         if self._bright_row and brightness is not None:
             lo, hi = caps.brightness_range
             pct = round((brightness - lo) / (hi - lo) * 100) if hi > lo else 0
@@ -1506,6 +1949,8 @@ X-GNOME-Autostart-enabled=true
         for i, row in enumerate(self._dpi_rows):
             row.set_value(stages[i][0] if i < len(stages) else 800)
             row.set_sensitive(i < num)
+        if self._home_dpi_row is not None and 1 <= active <= len(stages):
+            self._home_dpi_row.set_subtitle(f'{stages[active - 1][0]} DPI')
 
         if self._color_buttons and colors:
             for i, btn in enumerate(self._color_buttons):
@@ -1531,6 +1976,190 @@ X-GNOME-Autostart-enabled=true
         self._toast_overlay.add_toast(toast)
 
 
+class RemapButtonDialog(Adw.Window):
+    """Dialog for remapping a single mouse button via category + preset
+    dropdowns, rather than typing a raw --button spec string like the CLI.
+    Builds the same spec strings parse_button_function() already accepts
+    (e.g. 'left', 'dpi+', 'ctrl+c') from the selected dropdowns/checkboxes,
+    so it reuses all of hid.py's existing parsing/validation instead of
+    duplicating it.
+    """
+
+    _CATEGORIES = ['Mouse Click', 'Scroll', 'DPI', 'Profile Switch',
+                   'Media Key', 'Keyboard Shortcut', 'Disabled']
+    _MOD_NAMES = ['ctrl', 'shift', 'alt', 'super']
+
+    def __init__(self, btn_label: str, current_spec: str, on_applied, **kwargs):
+        super().__init__(**kwargs, title=f'Remap {btn_label}',
+                         default_width=360, default_height=-1)
+        self.set_modal(True)
+        self._on_applied = on_applied
+
+        toolbar = Adw.ToolbarView()
+        self.set_content(toolbar)
+        toolbar.add_top_bar(Adw.HeaderBar())
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(16)
+        box.set_margin_start(16)
+        box.set_margin_end(16)
+        toolbar.set_content(box)
+
+        group = Adw.PreferencesGroup()
+        box.append(group)
+
+        self._category_row = Adw.ComboRow()
+        self._category_row.set_title('Function')
+        self._category_row.set_model(Gtk.StringList.new(self._CATEGORIES))
+        self._category_row.connect('notify::selected', self._on_category_changed)
+        group.add(self._category_row)
+
+        self._sub_row = Adw.ComboRow()
+        self._sub_row.set_title('Action')
+        group.add(self._sub_row)
+
+        self._mod_row = Adw.ActionRow()
+        self._mod_row.set_title('Modifiers')
+        mod_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self._mod_checks = {}
+        for name in self._MOD_NAMES:
+            cb = Gtk.CheckButton(label=name.capitalize())
+            mod_box.append(cb)
+            self._mod_checks[name] = cb
+        self._mod_row.add_suffix(mod_box)
+        group.add(self._mod_row)
+
+        self._error_label = Gtk.Label()
+        self._error_label.add_css_class('error')
+        self._error_label.set_wrap(True)
+        self._error_label.set_visible(False)
+        box.append(self._error_label)
+
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8,
+                          halign=Gtk.Align.END)
+        cancel_btn = Gtk.Button(label='Cancel')
+        cancel_btn.connect('clicked', lambda _: self.close())
+        set_btn = Gtk.Button(label='Set')
+        set_btn.add_css_class('suggested-action')
+        set_btn.connect('clicked', self._on_set_clicked)
+        btn_box.append(cancel_btn)
+        btn_box.append(set_btn)
+        box.append(btn_box)
+
+        self._preselect(current_spec)
+
+    def _category_options(self, cat: str):
+        return {
+            'Mouse Click': list(MOUSE_ACTIONS),
+            'Scroll': list(SCROLL_ACTIONS),
+            'DPI': list(DPI_ACTIONS),
+            'Profile Switch': list(PROFILE_ACTIONS),
+            'Media Key': list(MEDIA_CODES),
+            'Keyboard Shortcut': sorted(HID_KEYS),
+        }.get(cat, [])
+
+    def _on_category_changed(self, *_args):
+        self._update_visible_rows()
+
+    def _update_visible_rows(self):
+        # Only reached via _on_category_changed() (the user picking a
+        # different category), never during __init__ - _preselect() below
+        # already fully owns initial model/visibility/selection, and
+        # rebuilding the model here would reset that selection back to 0.
+        cat = self._CATEGORIES[self._category_row.get_selected()]
+        if cat == 'Disabled':
+            self._sub_row.set_visible(False)
+            self._mod_row.set_visible(False)
+            return
+        self._sub_row.set_visible(True)
+        self._sub_row.set_title('Key' if cat == 'Keyboard Shortcut' else 'Action')
+        options = self._category_options(cat)
+        self._sub_row.set_model(Gtk.StringList.new([o.capitalize() for o in options]))
+        self._mod_row.set_visible(cat == 'Keyboard Shortcut')
+
+    def _preselect(self, spec: str):
+        spec = (spec or '').strip().lower()
+        if not spec or spec == '–' or spec == 'disabled':
+            self._category_row.set_selected(self._CATEGORIES.index('Disabled'))
+            self._sub_row.set_visible(False)
+            self._mod_row.set_visible(False)
+            return
+        if spec in MOUSE_ACTIONS:
+            self._select(spec, 'Mouse Click', list(MOUSE_ACTIONS))
+            return
+        if spec in SCROLL_ACTIONS:
+            self._select(spec, 'Scroll', list(SCROLL_ACTIONS))
+            return
+        if spec in DPI_ACTIONS:
+            self._select(spec, 'DPI', list(DPI_ACTIONS))
+            return
+        if spec in PROFILE_ACTIONS:
+            self._select(spec, 'Profile Switch', list(PROFILE_ACTIONS))
+            return
+        if spec in MEDIA_CODES:
+            self._select(spec, 'Media Key', list(MEDIA_CODES))
+            return
+        # Keyboard shortcut: mod+mod+key, every part a known modifier/key -
+        # same vocabulary check parse_button_function() itself uses.
+        parts = spec.split('+')
+        mods = [p for p in parts if p in HID_MODS]
+        keys = [p for p in parts if p in HID_KEYS]
+        if keys and len(mods) + len(keys) == len(parts):
+            self._category_row.set_selected(self._CATEGORIES.index('Keyboard Shortcut'))
+            self._sub_row.set_model(Gtk.StringList.new([k.capitalize() for k in sorted(HID_KEYS)]))
+            self._sub_row.set_title('Key')
+            self._sub_row.set_visible(True)
+            self._mod_row.set_visible(True)
+            try:
+                self._sub_row.set_selected(sorted(HID_KEYS).index(keys[0]))
+            except ValueError:
+                pass
+            for name, cb in self._mod_checks.items():
+                cb.set_active(name in mods or (name == 'super' and 'gui' in mods))
+            return
+        # Unrecognised (raw hex fallback from describe_button(), or a type
+        # this dialog doesn't model) - default to Mouse Click/Left rather
+        # than guessing further.
+        self._select('left', 'Mouse Click', list(MOUSE_ACTIONS))
+
+    def _select(self, value, category, options):
+        self._category_row.set_selected(self._CATEGORIES.index(category))
+        self._sub_row.set_model(Gtk.StringList.new([o.capitalize() for o in options]))
+        self._sub_row.set_title('Action')
+        self._sub_row.set_visible(True)
+        self._mod_row.set_visible(False)
+        try:
+            self._sub_row.set_selected(options.index(value))
+        except ValueError:
+            pass
+
+    def _build_spec(self) -> str:
+        cat = self._CATEGORIES[self._category_row.get_selected()]
+        if cat == 'Disabled':
+            return 'disabled'
+        options = self._category_options(cat)
+        idx = self._sub_row.get_selected()
+        if idx == Gtk.INVALID_LIST_POSITION or idx >= len(options):
+            raise ValueError('Choose an action')
+        value = options[idx]
+        if cat == 'Keyboard Shortcut':
+            mods = [name for name, cb in self._mod_checks.items() if cb.get_active()]
+            return '+'.join(mods + [value])
+        return value
+
+    def _on_set_clicked(self, _btn):
+        try:
+            spec = self._build_spec()
+            t, a1, a2 = parse_button_function(spec)
+        except ValueError as e:
+            self._error_label.set_label(str(e))
+            self._error_label.set_visible(True)
+            return
+        self.close()
+        self._on_applied(t, a1, a2)
+
+
 class InputTestDialog(Adw.Window):
     """Input test dialog with a mouse diagram and event log."""
 
@@ -1544,10 +2173,143 @@ class InputTestDialog(Adw.Window):
     _GTK_BTN_NAMES = {1: 'Left', 2: 'Middle', 3: 'Right',
                        8: 'Back (both sides)', 9: 'Forward (both sides)'}
 
+    # User-provided top-down mouse artwork (single fill path, 800x800
+    # source canvas) - drawn via _draw_svg_path() rather than hand-
+    # transcribed into Cairo calls, since hand-copying ~50 curve segments
+    # into Python literals is exactly the kind of thing that silently
+    # introduces a typo'd control point. Parsed once at class-definition
+    # time (see _ICON_SEGMENTS/_ICON_BBOX below), not per-frame.
+    _ICON_PATH_D = (
+        "M 499.50 455.52 C487.38,457.50 478.28,456.98 464.89,453.55 "
+        "C458.21,451.84 443.77,445.39 438.99,441.99 L 436.00 439.86 "
+        "L 436.00 425.31 C436.00,399.22 430.99,375.90 415.97,332.05 "
+        "C410.98,317.50 407.04,304.45 407.20,303.05 "
+        "C407.46,300.82 408.82,299.97 418.07,296.27 "
+        "C453.93,281.91 494.45,279.18 532.60,288.55 "
+        "C548.28,292.40 566.86,299.35 568.48,301.97 "
+        "C568.82,302.52 564.16,317.93 558.12,336.23 "
+        "C543.08,381.85 539.02,400.93 539.01,426.08 L 539.01 426.71 "
+        "C539.00,434.75 539.00,438.52 537.25,441.08 "
+        "C535.65,443.41 532.62,444.74 526.83,447.38 "
+        "C517.15,451.79 510.82,453.68 499.50,455.52 "
+        "ZM 570.52 292.96 C569.75,294.21 568.99,294.23 567.00,293.06 "
+        "C564.01,291.30 541.30,283.84 533.15,281.93 "
+        "C522.61,279.46 506.36,277.00 500.57,277.00 "
+        "C498.13,277.00 494.98,276.56 493.57,276.02 "
+        "C491.17,275.11 491.00,274.61 491.00,268.45 "
+        "C491.00,262.51 491.27,261.63 493.67,259.67 "
+        "C500.58,254.04 503.85,250.19 504.88,246.48 "
+        "C506.21,241.70 506.33,211.12 505.04,205.58 "
+        "C503.92,200.74 501.36,197.19 496.91,194.27 "
+        "C494.40,192.62 492.96,191.71 492.13,190.41 "
+        "C491.00,188.64 491.00,186.16 491.00,180.15 L 491.00 179.58 "
+        "C491.00,166.32 491.04,166.29 502.78,167.91 "
+        "C528.36,171.43 549.81,180.74 559.44,192.49 "
+        "C570.50,205.99 575.77,228.77 574.69,258.50 "
+        "C574.15,273.22 572.07,290.46 570.52,292.96 "
+        "ZM 417.34 289.47 C405.40,294.41 405.37,294.41 404.63,292.48 "
+        "C402.52,286.97 400.80,263.37 401.28,246.50 "
+        "C401.86,225.84 404.20,214.47 410.32,202.43 "
+        "C417.66,187.97 433.04,177.37 455.00,171.64 "
+        "C467.62,168.34 481.82,166.42 483.23,167.83 "
+        "C483.82,168.42 484.33,173.54 484.39,179.56 "
+        "C484.49,189.64 484.37,190.32 482.18,191.86 "
+        "C470.04,200.42 470.00,200.54 470.00,226.30 "
+        "C470.00,250.69 470.18,251.31 478.98,257.50 "
+        "C482.66,260.08 483.62,261.42 484.32,264.96 "
+        "C484.79,267.33 484.90,270.74 484.56,272.53 "
+        "C483.87,276.22 482.21,276.97 474.63,276.99 "
+        "C461.10,277.02 432.24,283.31 417.34,289.47 "
+        "ZM 555.06 427.34 L 554.65 427.77 "
+        "C550.42,432.24 548.26,434.52 547.15,434.09 "
+        "C546.00,433.64 546.00,430.23 546.00,423.27 L 546.00 422.63 "
+        "C546.00,404.04 550.80,379.12 559.70,351.50 "
+        "C565.22,334.36 566.76,332.00 572.47,332.00 "
+        "C575.40,332.00 575.58,332.54 577.58,346.74 "
+        "C582.20,379.64 574.63,406.71 555.06,427.34 "
+        "ZM 429.90 424.46 C429.85,427.78 429.48,431.62 429.10,433.00 "
+        "C428.42,435.41 428.14,435.24 420.95,427.94 "
+        "C409.17,415.98 401.85,401.49 398.43,383.34 "
+        "C396.51,373.14 396.95,348.86 399.24,338.50 "
+        "C400.43,333.15 400.86,332.47 403.24,332.19 "
+        "C408.06,331.62 409.58,333.44 413.37,344.22 "
+        "C423.01,371.71 430.20,406.59 429.90,424.46 "
+        "ZM 495.75 249.48 C490.47,255.09 483.56,254.83 478.51,248.83 "
+        "L 475.86 245.68 L 476.18 225.26 L 476.50 204.84 L 480.24 201.42 "
+        "C485.92,196.22 493.20,197.00 497.00,203.23 "
+        "C498.81,206.21 498.99,208.27 499.00,226.26 L 499.00 246.03 "
+        "ZM 406.00 324.18 C406.00,325.52 401.74,325.07 398.26,323.36 "
+        "C393.76,321.14 391.31,316.68 388.59,305.82 "
+        "C384.50,289.48 384.48,289.15 387.69,287.93 "
+        "C389.23,287.34 391.91,287.14 393.66,287.46 "
+        "C396.79,288.05 396.89,288.26 399.06,297.78 "
+        "C400.27,303.13 402.33,311.07 403.63,315.43 "
+        "C404.94,319.79 406.00,323.72 406.00,324.18 "
+        "ZM 578.91 322.22 C577.56,323.23 574.79,324.32 572.76,324.65 "
+        "L 569.07 325.25 L 570.12 321.88 "
+        "C570.69,320.02 572.87,311.75 574.94,303.50 L 578.73 288.50 "
+        "L 590.29 287.89 L 589.66 293.20 "
+        "C588.13,306.22 583.46,318.82 578.91,322.22 "
+        "ZM 394.68 280.22 C393.12,281.21 389.04,281.09 386.25,279.97 "
+        "C384.08,279.10 384.00,278.61 384.02,266.28 "
+        "C384.05,252.08 385.81,245.75 390.21,244.11 "
+        "C393.37,242.93 393.96,244.23 394.02,252.50 "
+        "C394.05,256.35 394.47,263.99 394.96,269.49 "
+        "C395.62,276.89 395.55,279.67 394.68,280.22 "
+        "ZM 590.24 279.35 C588.52,280.42 582.41,280.98 581.20,280.18 "
+        "C580.15,279.48 580.12,275.99 581.07,261.41 "
+        "C581.71,251.56 582.37,243.35 582.53,243.17 "
+        "C583.31,242.30 587.31,245.47 589.05,248.31 "
+        "C590.72,251.06 590.99,253.40 591.00,265.19 "
+        "C591.00,272.72 590.66,279.09 590.24,279.35 Z"
+    )
+
+    # Approximate centroids (in the icon's own 800x800 source space) of
+    # each interactive zone, eyeballed from the traced artwork's own
+    # sub-shapes (left/right click paddles at the top, the small oval
+    # between them for the wheel, the two side bars for thumb buttons).
+    # Used to position highlight rings on _draw() clicks/scroll/DPI events
+    # - the artwork itself doesn't carry this semantic info, so this is
+    # our own mapping on top of it, not something derived from the SVG.
+    # Centroids taken directly from each of the icon's own 10 subpaths
+    # (computed with _svg_path_bbox() per-subpath, not eyeballed) so
+    # every highlight actually lands on the shape it's meant to indicate.
+    _ICON_ZONES = {
+        1: (443, 230),        # left click paddle (subpath 2)
+        3: (533, 230),        # right click paddle (subpath 1)
+        2: (487, 226),        # wheel (subpath 5)
+        'scroll_up': (487, 183),    # above the wheel, not on top of it
+        'scroll_down': (487, 269),  # below the wheel
+        'dpi': (487, 182),
+        # GTK's back(8)/forward(9) codes don't say which physical side
+        # was pressed - the OS can't tell, since both sides of a
+        # symmetric thumb pair report the same code (see _GTK_BTN_NAMES'
+        # "both sides" labels). So unlike the zones above, 8/9 aren't
+        # looked up directly here - _draw() lights up every caps.buttons
+        # thumb name whose *default* binding matches that direction
+        # (thumb1/thumb3 = front = forward, thumb2/thumb4 = back, per
+        # each driver's own comments). Forward sits on the small thumb-
+        # click bar (subpaths 8/9); back sits lower, on the larger grip
+        # panel beneath it (subpaths 4/3) - two visually distinct shapes
+        # in the artwork, not one bar sharing both meanings.
+        'thumb1': (390, 262),   # left, front/forward (subpath 8)
+        'thumb2': (395, 306),   # left, back (subpath 6 - between the thumb
+                                 # bar and the larger lower panel, not the
+                                 # panel itself)
+        'thumb3': (586, 262),   # right, front/forward (subpath 9)
+        'thumb4': (580, 307),   # right, back (subpath 7, same as above)
+    }
+
+    # Parsed once at class-definition time, not per-frame - _draw() runs
+    # on every pointer move over the diagram.
+    _ICON_SEGMENTS = _parse_svg_path(_ICON_PATH_D)
+    _ICON_BBOX = _svg_path_bbox(_ICON_SEGMENTS)
+
     def __init__(self, device: PulsarDevice | None = None, **kwargs):
         super().__init__(**kwargs, title='Input Test', default_width=380, default_height=520)
         self.set_modal(True)
         self._device = device
+        self._buttons = device.capabilities.buttons if device else {}
 
         self._left_handed = False
         try:
@@ -1706,156 +2468,63 @@ class InputTestDialog(Adw.Window):
         cr.paint()
 
         mx, my, mw, mh = w * 0.15, h * 0.02, w * 0.7, h * 0.92
-        cx = mx + mw / 2
-        cr.set_source_rgb(0.30, 0.30, 0.33)
-        self._body_path(cr, mx, my, mw, mh, cx)
-        cr.fill()
+        bx0, by0, bx1, by1 = self._ICON_BBOX
+        sx = mw / (bx1 - bx0)
+        sy = mh / (by1 - by0)
+        tx = mx - bx0 * sx
+        ty = my - by0 * sy
 
-        # Left/right click zones - drawn as persistent visible buttons
-        # (like the thumb buttons below), not just a highlight that only
-        # appears while clicked, so they read as obvious click targets.
-        # Clipped to the body outline so they follow the domed shell
-        # shape (rounded top corners etc.) instead of overflowing it as
-        # plain rectangles - rects below are sized to overshoot the body
-        # edges slightly and let the clip do the rounding. Drawn before
-        # the scroll wheel/divider so those render on top, like they
-        # physically sit above the button housings.
-        cr.save()
-        self._body_path(cr, mx, my, mw, mh, cx)
-        cr.clip()
-        lr_buttons = {1: 'L', 3: 'R'}
-        lr_zones = {
-            1: (mx, my, mw * 0.49, mh * 0.36),
-            3: (mx + mw * 0.51, my, mw * 0.49, mh * 0.36),
-        }
-        for btn_id, label in lr_buttons.items():
-            zx, zy, zw, zh = lr_zones[btn_id]
-            if self._active_btn == btn_id:
-                cr.set_source_rgb(0.3, 0.7, 1.0)
-            else:
-                cr.set_source_rgb(0.40, 0.40, 0.44)
-            self._rounded_rect(cr, zx, zy, zw, zh, 10)
-            cr.fill()
-            cr.set_source_rgb(0.9, 0.9, 0.9)
-            cr.set_font_size(12)
-            ext = cr.text_extents(label)
-            cr.move_to(zx + zw / 2 - ext.width / 2, zy + zh * 0.55)
-            cr.show_text(label)
-        cr.restore()
-
-        cr.set_source_rgb(0.20, 0.20, 0.22)
-        cr.set_line_width(2)
-        cr.move_to(w * 0.5, my)
-        cr.line_to(w * 0.5, my + mh * 0.40)
-        cr.stroke()
-
-        ww, wh = mw * 0.18, mh * 0.18
-        wx = w * 0.5 - ww / 2
-        wy = my + mh * 0.08
-        is_scroll = isinstance(self._active_btn, str) and self._active_btn.startswith('scroll')
-        if is_scroll or self._active_btn == 2:
-            cr.set_source_rgb(0.3, 0.7, 1.0)
+        # Which zone(s) should glow. Most active states (including
+        # 'scroll_up'/'scroll_down', which have their own positions above
+        # and below the wheel rather than sharing its dot) map to exactly
+        # one; GTK's back(8)/forward(9) can map to two (a 4-thumb-button
+        # device like the X2A has a front+back pair on each side, and the
+        # OS can't say which side was pressed - see _ICON_ZONES' comment)
+        # or one (the FO1's thumb1/thumb2, both on the left).
+        active = self._active_btn
+        if active == 9:
+            positions = [self._ICON_ZONES[n] for n in ('thumb1', 'thumb3')
+                        if n in self._buttons]
+        elif active == 8:
+            positions = [self._ICON_ZONES[n] for n in ('thumb2', 'thumb4')
+                        if n in self._buttons]
+        elif active in self._ICON_ZONES:
+            positions = [self._ICON_ZONES[active]]
         else:
-            cr.set_source_rgb(0.45, 0.45, 0.50)
-        self._rounded_rect(cr, wx, wy, ww, wh, ww * 0.3)
+            positions = []
+
+        cr.set_source_rgb(0.55, 0.55, 0.58)
+        _draw_svg_path(cr, self._ICON_SEGMENTS, tx, ty, sx, sy)
         cr.fill()
 
-        if self._active_btn == 'scroll_up':
-            cr.set_source_rgb(1, 1, 1)
-            cr.move_to(wx + ww / 2, wy + 3)
-            cr.line_to(wx + ww / 2 - 4, wy + wh / 2)
-            cr.line_to(wx + ww / 2 + 4, wy + wh / 2)
-            cr.close_path()
-            cr.fill()
-        elif self._active_btn == 'scroll_down':
-            cr.set_source_rgb(1, 1, 1)
-            cr.move_to(wx + ww / 2, wy + wh - 3)
-            cr.line_to(wx + ww / 2 - 4, wy + wh / 2)
-            cr.line_to(wx + ww / 2 + 4, wy + wh / 2)
-            cr.close_path()
+        # Glow drawn on top of the icon, not behind it - the left/right
+        # click zones sit under solid opaque paddle shapes in the traced
+        # artwork, so a glow drawn first would be completely covered
+        # there (only visible over thin/outline areas like the wheel or
+        # thumb bars). Translucent so the linework still shows through.
+        r = 15 * min(sx, sy)
+        for zx, zy in positions:
+            gcx, gcy = zx * sx + tx, zy * sy + ty
+            cr.set_source_rgba(0.3, 0.7, 1.0, 0.65)
+            cr.arc(gcx, gcy, r, 0, 2 * math.pi)
             cr.fill()
 
-        thumb_buttons = [
-            ('left',  0.38, 'FWD',  9),
-            ('left',  0.52, 'BACK', 8),
-        ]
-        for side, ty, label, btn_id in thumb_buttons:
-            if side == 'left':
-                bx = mx - mw * 0.08
-            else:
-                bx = mx + mw * 0.90
-            by = my + mh * ty
-            bw = mw * 0.18
-            bh = mh * 0.10
-            if self._active_btn == btn_id:
-                cr.set_source_rgb(0.3, 0.7, 1.0)
-            else:
-                cr.set_source_rgb(0.40, 0.40, 0.44)
-            self._rounded_rect(cr, bx, by, bw, bh, 4)
-            cr.fill()
-            cr.set_source_rgb(0.9, 0.9, 0.9)
-            cr.set_font_size(9)
-            ext = cr.text_extents(label)
-            cr.move_to(bx + bw / 2 - ext.width / 2, by + bh / 2 + ext.height / 2)
-            cr.show_text(label)
-
-        dx, dy = mx + mw * 0.22, my + mh * 0.45
-        dr = 7 if self._active_btn == 'dpi' else 5
-        if self._active_btn == 'dpi':
-            cr.set_source_rgb(0.3, 0.7, 1.0)
-        else:
-            cr.set_source_rgb(0.50, 0.50, 0.55)
-        cr.arc(dx, dy, dr, 0, 2 * math.pi)
-        cr.fill()
-        cr.set_source_rgb(0.9, 0.9, 0.9) if self._active_btn == 'dpi' else cr.set_source_rgb(0.7, 0.7, 0.7)
-        cr.set_font_size(8)
-        ext = cr.text_extents('DPI')
-        cr.move_to(dx - ext.width / 2, dy + dr + ext.height + 2)
-        cr.show_text('DPI')
-
-    @staticmethod
-    def _body_path(cr, mx, my, mw, mh, cx):
-        """Traces the mouse body silhouette without filling it - shared
-        by the body fill and the L/R button clip so both use the exact
-        same outline (see _draw())."""
-        cr.new_path()
-        cr.move_to(cx, my)
-        cr.curve_to(mx + mw * 0.80, my,
-                    mx + mw * 0.94, my + mh * 0.04,
-                    mx + mw * 0.94, my + mh * 0.12)
-        cr.curve_to(mx + mw * 0.94, my + mh * 0.30,
-                    mx + mw * 0.90, my + mh * 0.40,
-                    mx + mw * 0.90, my + mh * 0.50)
-        cr.curve_to(mx + mw * 0.90, my + mh * 0.62,
-                    mx + mw * 0.93, my + mh * 0.72,
-                    mx + mw * 0.92, my + mh * 0.82)
-        cr.curve_to(mx + mw * 0.91, my + mh * 0.92,
-                    mx + mw * 0.75, my + mh,
-                    cx, my + mh)
-        cr.curve_to(mx + mw * 0.25, my + mh,
-                    mx + mw * 0.09, my + mh * 0.92,
-                    mx + mw * 0.08, my + mh * 0.82)
-        cr.curve_to(mx + mw * 0.07, my + mh * 0.72,
-                    mx + mw * 0.10, my + mh * 0.62,
-                    mx + mw * 0.10, my + mh * 0.50)
-        cr.curve_to(mx + mw * 0.10, my + mh * 0.40,
-                    mx + mw * 0.06, my + mh * 0.30,
-                    mx + mw * 0.06, my + mh * 0.12)
-        cr.curve_to(mx + mw * 0.06, my + mh * 0.04,
-                    mx + mw * 0.20, my,
-                    cx, my)
-        cr.close_path()
-
-    @staticmethod
-    def _rounded_rect(cr, x, y, w, h, r):
-        import math
-        r = min(r, w / 2, h / 2)
-        cr.new_path()
-        cr.arc(x + r, y + r, r, math.pi, 1.5 * math.pi)
-        cr.arc(x + w - r, y + r, r, 1.5 * math.pi, 2 * math.pi)
-        cr.arc(x + w - r, y + h - r, r, 0, 0.5 * math.pi)
-        cr.arc(x + r, y + h - r, r, 0.5 * math.pi, math.pi)
-        cr.close_path()
+            # Scroll direction arrow, drawn on top of the wheel's glow -
+            # a plain wheel click and a scroll are otherwise the same dot.
+            if active == 'scroll_up':
+                cr.set_source_rgb(1, 1, 1)
+                cr.move_to(gcx, gcy - r * 0.5)
+                cr.line_to(gcx - r * 0.45, gcy + r * 0.3)
+                cr.line_to(gcx + r * 0.45, gcy + r * 0.3)
+                cr.close_path()
+                cr.fill()
+            elif active == 'scroll_down':
+                cr.set_source_rgb(1, 1, 1)
+                cr.move_to(gcx, gcy + r * 0.5)
+                cr.line_to(gcx - r * 0.45, gcy - r * 0.3)
+                cr.line_to(gcx + r * 0.45, gcy - r * 0.3)
+                cr.close_path()
+                cr.fill()
 
 
 def main():

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -289,7 +289,7 @@ class PulsarMouseApp(Adw.Application):
 
     def _build_tray(self, win: 'MainWindow', device: PulsarDevice):
         caps = device.capabilities
-        sni = _StatusNotifierItem('pulsar-mouse', 'pulsar-mouse', caps.name)
+        sni = _StatusNotifierItem('pulsar-mouse', 'input-mouse', caps.name)
         sni.set_on_activate(win.present)
         self._sni = sni
 

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -34,6 +34,28 @@ APP_ID = 'io.github.packerlschupfer.PulsarMouse'
 # Serialises all USB open/close operations so the tray and window don't collide.
 _USB_LOCK = threading.Lock()
 
+# Minimum time between forwarded signal_percent hidraw events (the device
+# pushes these at ~1Hz - that's overkill for a status readout, so both the
+# Home page and the tray throttle down to this).
+_SIGNAL_UPDATE_INTERVAL = 20.0
+
+
+def _connection_quality_label(pct):
+    # Bands are this app's own estimate, not confirmed against Fusion's
+    # exact thresholds - see feinmann8k.py's parse_hidraw_event() docstring
+    # for how the underlying value was confirmed to mean signal quality at
+    # all (a capture where moving the mouse away from the dongle dropped it
+    # from ~90 to ~39).
+    if pct >= 80:
+        return 'Excellent'
+    if pct >= 60:
+        return 'Good'
+    if pct >= 40:
+        return 'Fair'
+    if pct >= 20:
+        return 'Weak'
+    return 'Poor'
+
 _SNI_XML = """
 <node>
   <interface name="org.kde.StatusNotifierItem">
@@ -187,6 +209,9 @@ class PulsarMouseApp(Adw.Application):
         item_open.connect('item-activated', lambda _i, _t: win.present())
         root.child_append(item_open)
 
+        self._battery_text = None
+        self._conn_text = None
+
         self._battery_item = None
         if hasattr(device, 'get_power'):
             battery_item = Dbusmenu.Menuitem.new()
@@ -197,6 +222,21 @@ class PulsarMouseApp(Adw.Application):
                 pass  # cosmetic only - fine if this binding doesn't support it
             root.child_append(battery_item)
             self._battery_item = battery_item
+
+        # Connection Quality has no synchronous getter (see the Home page's
+        # own comment on this) - it only ever arrives via async hidraw
+        # events, so unlike Battery this item stays "—" until the first one
+        # shows up rather than being read up front.
+        self._conn_item = None
+        if hasattr(device, 'find_hidraw'):
+            conn_item = Dbusmenu.Menuitem.new()
+            conn_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Connection Quality: —')
+            try:
+                conn_item.property_set_bool(Dbusmenu.MENUITEM_PROP_ENABLED, False)
+            except Exception:
+                pass
+            root.child_append(conn_item)
+            self._conn_item = conn_item
 
         sep1 = Dbusmenu.Menuitem.new()
         sep1.property_set(Dbusmenu.MENUITEM_PROP_TYPE, Dbusmenu.CLIENT_TYPES_SEPARATOR)
@@ -322,11 +362,23 @@ class PulsarMouseApp(Adw.Application):
     def _set_battery_label(self, pwr):
         pct = pwr['battery_percent']
         charging = ' (charging)' if pwr['power_connected'] else ''
-        text = f'Battery: {pct}%{charging}'
+        self._battery_text = f'Battery: {pct}%{charging}'
         if self._battery_item is not None:
-            self._battery_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, text)
-        if self._sni is not None:
-            self._sni.set_tooltip(text)
+            self._battery_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, self._battery_text)
+        self._update_tray_tooltip()
+
+    def _set_conn_quality_label(self, pct):
+        self._conn_text = f'Connection Quality: {pct}%  —  {_connection_quality_label(pct)}'
+        if self._conn_item is not None:
+            self._conn_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, self._conn_text)
+        self._update_tray_tooltip()
+
+    def _update_tray_tooltip(self):
+        if self._sni is None:
+            return
+        lines = [t for t in (self._battery_text, self._conn_text) if t]
+        if lines:
+            self._sni.set_tooltip('\n'.join(lines))
 
     def _hidraw_listener(self):
         device = self._device
@@ -339,14 +391,22 @@ class PulsarMouseApp(Adw.Application):
             fd = os.open(path, os.O_RDONLY)
         except OSError:
             return
+        last_signal_update = 0.0
         try:
             while True:
                 data = os.read(fd, 256)
                 if not data:
                     break
                 event = device.parse_hidraw_event(data)
-                if event:
+                if not event:
+                    continue
+                if 'dpi' in event:
                     GLib.idle_add(self._update_tray_label, event['dpi'], None)
+                elif 'signal_percent' in event:
+                    now = time.monotonic()
+                    if now - last_signal_update >= _SIGNAL_UPDATE_INTERVAL:
+                        last_signal_update = now
+                        GLib.idle_add(self._set_conn_quality_label, event['signal_percent'])
         except OSError:
             pass
         finally:
@@ -469,17 +529,67 @@ class MainWindow(Adw.ApplicationWindow):
 
         self._build_ui()
         GLib.idle_add(self._reload)
+        GLib.idle_add(self._start_home_updates)
 
     def _build_ui(self):
         caps = self._caps
-        toolbar_view = Adw.ToolbarView()
-        self.set_content(toolbar_view)
 
-        # ── Header bar ───────────────────────────────────────────────────
-        header = Adw.HeaderBar()
+        if not caps:
+            # No device found - a minimal single-pane message instead of
+            # the tabbed layout below, which assumes caps/device exist
+            # throughout.
+            toolbar_view = Adw.ToolbarView()
+            self.set_content(toolbar_view)
+            toolbar_view.add_top_bar(Adw.HeaderBar())
+            self._banner = Adw.Banner()
+            self._banner.set_title('No supported mouse found')
+            self._banner.set_revealed(True)
+            toolbar_view.set_content(self._banner)
+            self._toast_overlay = None
+            return
 
-        # Profile selector (hidden if only 1 profile)
-        if caps and caps.num_profiles > 1:
+        split_view = Adw.NavigationSplitView()
+        split_view.set_min_sidebar_width(180)
+        split_view.set_max_sidebar_width(220)
+        self.set_content(split_view)
+
+        # ── Sidebar navigation ─────────────────────────────────────────
+        sidebar_toolbar = Adw.ToolbarView()
+        sidebar_header = Adw.HeaderBar()
+        sidebar_header.set_show_end_title_buttons(False)
+        sidebar_toolbar.add_top_bar(sidebar_header)
+
+        nav_list = Gtk.ListBox()
+        nav_list.add_css_class('navigation-sidebar')
+        nav_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
+
+        # (view-stack page name, sidebar label, icon) - order here is the
+        # order rows appear in the sidebar and must line up with
+        # nav_list's row index in _on_nav_row_selected() below.
+        self._nav_pages = [
+            ('home', 'Home', 'go-home-symbolic'),
+            ('performance', 'Performance', 'preferences-system-symbolic'),
+            ('customize', 'Customize', 'preferences-desktop-symbolic'),
+            ('power', 'Power', 'battery-good-symbolic'),
+        ]
+        for _name, label, icon in self._nav_pages:
+            row = Adw.ActionRow()
+            row.set_title(label)
+            row.add_prefix(Gtk.Image.new_from_icon_name(icon))
+            nav_list.append(row)
+        nav_list.connect('row-selected', self._on_nav_row_selected)
+        sidebar_toolbar.set_content(nav_list)
+        sidebar_page = Adw.NavigationPage.new(sidebar_toolbar, caps.name)
+        split_view.set_sidebar(sidebar_page)
+
+        # ── Content: header bar (Apply/Reload/profile - shared across all
+        # tabs, not per-tab, since Apply always writes everything pending
+        # regardless of which tab is showing) + a ViewStack switched by
+        # the sidebar ─────────────────────────────────────────────────
+        content_toolbar = Adw.ToolbarView()
+        content_header = Adw.HeaderBar()
+
+        if caps.num_profiles > 1:
             profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
             profile_box.append(Gtk.Label(label='Profile:'))
             self._profile_combo = Gtk.DropDown.new_from_strings(
@@ -487,33 +597,62 @@ class MainWindow(Adw.ApplicationWindow):
             )
             self._profile_combo.connect('notify::selected', self._on_profile_changed)
             profile_box.append(self._profile_combo)
-            header.set_title_widget(profile_box)
+            content_header.set_title_widget(profile_box)
         else:
             self._profile_combo = None
 
         reload_btn = Gtk.Button(icon_name='view-refresh-symbolic')
         reload_btn.set_tooltip_text('Reload from mouse')
         reload_btn.connect('clicked', lambda _: self._reload())
-        header.pack_start(reload_btn)
+        content_header.pack_start(reload_btn)
 
         apply_btn = Gtk.Button(label='Apply')
         apply_btn.add_css_class('suggested-action')
         apply_btn.connect('clicked', lambda _: self._apply())
-        header.pack_end(apply_btn)
+        content_header.pack_end(apply_btn)
 
-        toolbar_view.add_top_bar(header)
+        content_toolbar.add_top_bar(content_header)
 
-        # ── Toast overlay ────────────────────────────────────────────────
         toast_overlay = Adw.ToastOverlay()
-        toolbar_view.set_content(toast_overlay)
         self._toast_overlay = toast_overlay
+        content_toolbar.set_content(toast_overlay)
 
-        # ── Scrollable content ───────────────────────────────────────────
+        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        toast_overlay.set_child(content_box)
+
+        # Error banner - shared across tabs (sits above whichever page is
+        # visible), same as the single-page layout this replaced.
+        self._banner = Adw.Banner()
+        self._banner.set_revealed(False)
+        content_box.append(self._banner)
+
+        self._view_stack = Adw.ViewStack()
+        self._view_stack.set_vexpand(True)
+        content_box.append(self._view_stack)
+
+        self._view_stack.add_named(self._build_home_page(), 'home')
+        self._view_stack.add_named(self._build_performance_page(), 'performance')
+        self._view_stack.add_named(self._build_customize_page(), 'customize')
+        self._view_stack.add_named(self._build_power_page(), 'power')
+
+        content_page = Adw.NavigationPage.new(content_toolbar, 'Settings')
+        split_view.set_content(content_page)
+
+        nav_list.select_row(nav_list.get_row_at_index(0))
+
+    def _on_nav_row_selected(self, _listbox, row):
+        if row is None:
+            return
+        name = self._nav_pages[row.get_index()][0]
+        self._view_stack.set_visible_child_name(name)
+
+    def _wrap_page(self, *groups):
+        """Common scrolled+clamp wrapper for a ViewStack page - same
+        max-width clamp and margins the single-page layout used to use
+        for its one long page, just repeated per tab now."""
         scroll = Gtk.ScrolledWindow()
         scroll.set_hexpand(True)
         scroll.set_vexpand(True)
-        toast_overlay.set_child(scroll)
-
         clamp = Adw.Clamp()
         clamp.set_maximum_size(600)
         clamp.set_margin_top(24)
@@ -521,27 +660,90 @@ class MainWindow(Adw.ApplicationWindow):
         clamp.set_margin_start(12)
         clamp.set_margin_end(12)
         scroll.set_child(clamp)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=24)
+        clamp.set_child(box)
+        for g in groups:
+            box.append(g)
+        return scroll
 
-        page_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=24)
-        clamp.set_child(page_box)
+    def _build_home_page(self):
+        """Status/landing tab: device name, connection, battery, and
+        wireless signal quality - populated live by _start_home_updates(),
+        called once from __init__ after the window itself exists.
+        """
+        caps = self._caps
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        box.set_valign(Gtk.Align.START)
+        box.set_margin_top(48)
+        box.set_margin_start(24)
+        box.set_margin_end(24)
 
-        # Error banner
-        self._banner = Adw.Banner()
-        self._banner.set_revealed(False)
-        page_box.append(self._banner)
+        icon = Gtk.Image.new_from_icon_name('input-mouse-symbolic')
+        icon.set_pixel_size(96)
+        icon.set_halign(Gtk.Align.CENTER)
+        box.append(icon)
 
-        if not caps:
-            self._banner.set_title('No supported mouse found')
-            self._banner.set_revealed(True)
-            return
+        title = Gtk.Label(label=caps.name)
+        title.add_css_class('title-1')
+        title.set_margin_top(12)
+        title.set_halign(Gtk.Align.CENTER)
+        box.append(title)
 
-        # ── Global settings ──────────────────────────────────────────────
+        status_group = Adw.PreferencesGroup()
+        status_group.set_margin_top(24)
+        box.append(status_group)
+
+        conn_row = Adw.ActionRow()
+        conn_row.set_title('Connection')
+        conn_row.set_subtitle('Wireless')
+        conn_row.add_prefix(Gtk.Image.new_from_icon_name('network-wireless-symbolic'))
+        connected_label = Gtk.Label(label='Connected')
+        connected_label.add_css_class('success')
+        conn_row.add_suffix(connected_label)
+        status_group.add(conn_row)
+
+        # Polling rate, kept in sync elsewhere: _populate_global() (on
+        # reload) and _apply() (immediately on Apply, before the write even
+        # finishes) - not event-driven, since polling rate only ever
+        # changes via this app, not something the device pushes on its own.
+        self._home_mode_row = Adw.ActionRow()
+        self._home_mode_row.set_title('Wireless Mode')
+        self._home_mode_row.set_subtitle('—')
+        self._home_mode_row.add_prefix(
+            Gtk.Image.new_from_icon_name('network-wireless-symbolic'))
+        status_group.add(self._home_mode_row)
+
+        device = self._device
+        if hasattr(device, 'get_power'):
+            self._home_battery_row = Adw.ActionRow()
+            self._home_battery_row.set_title('Battery')
+            self._home_battery_row.set_subtitle('—')
+            self._home_battery_row.add_prefix(
+                Gtk.Image.new_from_icon_name('battery-good-symbolic'))
+            status_group.add(self._home_battery_row)
+        else:
+            self._home_battery_row = None
+
+        # Always shown even though we can't know in advance whether this
+        # model actually pushes signal-quality events - it just stays
+        # "—" harmlessly if nothing ever arrives (see
+        # _home_hidraw_listener()).
+        self._home_signal_row = Adw.ActionRow()
+        self._home_signal_row.set_title('Connection Quality')
+        self._home_signal_row.set_subtitle('—')
+        self._home_signal_row.add_prefix(
+            Gtk.Image.new_from_icon_name('network-wireless-signal-good-symbolic'))
+        status_group.add(self._home_signal_row)
+
+        return box
+
+    def _build_performance_page(self):
+        caps = self._caps
+
         global_group = Adw.PreferencesGroup()
         global_group.set_title('Global Settings')
         global_group.set_description('Applies to all profiles')
-        page_box.append(global_group)
 
-        # Polling rate
         self._poll_row = Adw.ComboRow()
         self._poll_row.set_title('Polling Rate')
         self._poll_row.set_subtitle('Hz')
@@ -550,7 +752,6 @@ class MainWindow(Adw.ApplicationWindow):
         )
         global_group.add(self._poll_row)
 
-        # Debounce
         self._debounce_row = None
         if caps.has_debounce:
             lo, hi = caps.debounce_range
@@ -559,7 +760,6 @@ class MainWindow(Adw.ApplicationWindow):
                 format_value=lambda v: f'{int(v)} ms')
             global_group.add(row)
 
-        # Angle snap
         self._angle_row = None
         if caps.has_angle_snap:
             self._angle_row = Adw.SwitchRow()
@@ -567,7 +767,6 @@ class MainWindow(Adw.ApplicationWindow):
             self._angle_row.set_subtitle('Straightens cursor movement to horizontal/vertical lines')
             global_group.add(self._angle_row)
 
-        # Ripple control
         self._ripple_row = None
         if caps.has_ripple_control:
             self._ripple_row = Adw.SwitchRow()
@@ -575,7 +774,6 @@ class MainWindow(Adw.ApplicationWindow):
             self._ripple_row.set_subtitle('Smooths out sensor jitter at low speeds')
             global_group.add(self._ripple_row)
 
-        # Motion sync
         self._motion_row = None
         if caps.has_motion_sync:
             self._motion_row = Adw.SwitchRow()
@@ -583,12 +781,12 @@ class MainWindow(Adw.ApplicationWindow):
             self._motion_row.set_subtitle('Synchronises sensor data with USB polling interval')
             global_group.add(self._motion_row)
 
-        # ── Per-profile settings ─────────────────────────────────────────
-        profile_group = Adw.PreferencesGroup()
-        profile_group.set_title('Profile Settings')
-        page_box.append(profile_group)
+        # LOD lives here (not on the Customize tab with the rest of
+        # "Profile Settings") to match Fusion's own Performance tab, which
+        # groups Lift-off Distance with DPI/polling rate rather than LED.
+        tracking_group = Adw.PreferencesGroup()
+        tracking_group.set_title('Tracking')
 
-        # LOD
         self._lod_row = None
         if caps.lod_values:
             self._lod_row = Adw.ComboRow()
@@ -597,49 +795,10 @@ class MainWindow(Adw.ApplicationWindow):
             self._lod_row.set_model(
                 Gtk.StringList.new([f'{v} mm' for v in caps.lod_values])
             )
-            profile_group.add(self._lod_row)
+            tracking_group.add(self._lod_row)
 
-        # LED brightness - shown/edited as 0-100%, converted to the
-        # device's raw brightness_range (usually 0-255) at apply/reload
-        # time (see _apply()/_populate_profile()) so the on-wire value and
-        # the on-screen value don't have to match.
-        self._bright_row = None
-        if caps.has_led:
-            row, self._bright_row = self._make_slider_row(
-                'LED Brightness', '0% – 100%', 0, 100, 5,
-                format_value=lambda v: f'{int(v)}%')
-            profile_group.add(row)
-
-        # LED effect
-        self._led_row = None
-        if caps.has_led and caps.led_effects:
-            self._led_row = Adw.ComboRow()
-            self._led_row.set_title('LED Effect')
-            self._led_row.set_model(
-                Gtk.StringList.new([e.capitalize() for e in caps.led_effects])
-            )
-            self._led_row.connect('notify::selected', self._on_led_changed)
-            profile_group.add(self._led_row)
-
-        # Breath speed - self._breath_row is the Gtk.Scale (get_value/
-        # set_value, as elsewhere), self._breath_row_container is the
-        # wrapping Adw.ActionRow (title + slider together) - the visibility
-        # toggle below needs to hide/show the whole row, not just the
-        # slider inside it.
-        self._breath_row = None
-        self._breath_row_container = None
-        if caps.has_led and caps.has_breath_speed:
-            lo, hi = caps.breath_speed_range
-            self._breath_row_container, self._breath_row = self._make_slider_row(
-                'Breath Speed', '', lo, hi, 1,
-                marks=[(lo, 'Slow'), (hi, 'Fast')])
-            self._breath_row_container.set_visible(False)
-            profile_group.add(self._breath_row_container)
-
-        # ── DPI stages ───────────────────────────────────────────────────
         dpi_group = Adw.PreferencesGroup()
         dpi_group.set_title('DPI Stages')
-        page_box.append(dpi_group)
 
         self._stage_count_row = Adw.SpinRow.new_with_range(1, caps.max_dpi_stages, 1)
         self._stage_count_row.set_title('Number of Stages')
@@ -668,15 +827,98 @@ class MainWindow(Adw.ApplicationWindow):
             dpi_group.add(row)
             self._dpi_rows.append(row)
 
-        # ── Power Management ─────────────────────────────────────────────
+        groups = [global_group]
+        if caps.lod_values:
+            groups.append(tracking_group)
+        groups.append(dpi_group)
+        return self._wrap_page(*groups)
+
+    def _build_customize_page(self):
+        caps = self._caps
+
+        led_group = Adw.PreferencesGroup()
+        led_group.set_title('LED')
+
+        # LED brightness - shown/edited as 0-100%, converted to the
+        # device's raw brightness_range (usually 0-255) at apply/reload
+        # time (see _apply()/_populate_profile()) so the on-wire value and
+        # the on-screen value don't have to match.
+        self._bright_row = None
+        if caps.has_led:
+            row, self._bright_row = self._make_slider_row(
+                'LED Brightness', '0% – 100%', 0, 100, 5,
+                format_value=lambda v: f'{int(v)}%')
+            led_group.add(row)
+
+        self._led_row = None
+        if caps.has_led and caps.led_effects:
+            self._led_row = Adw.ComboRow()
+            self._led_row.set_title('LED Effect')
+            self._led_row.set_model(
+                Gtk.StringList.new([e.capitalize() for e in caps.led_effects])
+            )
+            self._led_row.connect('notify::selected', self._on_led_changed)
+            led_group.add(self._led_row)
+
+        # Breath speed - self._breath_row is the Gtk.Scale (get_value/
+        # set_value, as elsewhere), self._breath_row_container is the
+        # wrapping Adw.ActionRow (title + slider together) - the visibility
+        # toggle below needs to hide/show the whole row, not just the
+        # slider inside it.
+        self._breath_row = None
+        self._breath_row_container = None
+        if caps.has_led and caps.has_breath_speed:
+            lo, hi = caps.breath_speed_range
+            self._breath_row_container, self._breath_row = self._make_slider_row(
+                'Breath Speed', '', lo, hi, 1,
+                marks=[(lo, 'Slow'), (hi, 'Fast')])
+            self._breath_row_container.set_visible(False)
+            led_group.add(self._breath_row_container)
+
+        btn_group = Adw.PreferencesGroup()
+        btn_group.set_title('Button Bindings')
+        btn_group.set_description('Use the CLI (--button) to remap buttons')
+
+        self._btn_rows = {}
+        for btn_name, btn_id in caps.buttons.items():
+            row = Adw.ActionRow()
+            label = caps.button_labels.get(btn_name, btn_name.capitalize())
+            row.set_title(label)
+            row.set_subtitle('–')
+            btn_group.add(row)
+            self._btn_rows[btn_id] = row
+
+        actions_group = Adw.PreferencesGroup()
+
+        test_row = Adw.ButtonRow()
+        test_row.set_title('Test Input — click to test mouse buttons')
+        test_row.connect('activated', self._on_test_clicked)
+        actions_group.add(test_row)
+
+        if caps.has_reset:
+            reset_row = Adw.ButtonRow()
+            reset_row.set_title('Reset to Factory Defaults')
+            reset_row.add_css_class('destructive-action')
+            reset_row.connect('activated', self._on_reset_clicked)
+            actions_group.add(reset_row)
+
+        groups = []
+        if caps.has_led:
+            groups.append(led_group)
+        groups.append(btn_group)
+        groups.append(actions_group)
+        return self._wrap_page(*groups)
+
+    def _build_power_page(self):
+        device = self._device
         self._power_saving_row = None
         self._low_power_row = None
-        device = self._device
+        groups = []
+
         if hasattr(device, 'set_power_saving_timeout') or hasattr(device, 'set_low_power_threshold'):
             power_group = Adw.PreferencesGroup()
             power_group.set_title('Power Management')
             power_group.set_description('Wireless power-saving behaviour')
-            page_box.append(power_group)
 
             if hasattr(device, 'set_power_saving_timeout'):
                 row, self._power_saving_row = self._make_slider_row(
@@ -693,40 +935,85 @@ class MainWindow(Adw.ApplicationWindow):
                     0, 100, 5)
                 power_group.add(row)
 
-        # ── Button bindings (read-only display) ──────────────────────────
-        btn_group = Adw.PreferencesGroup()
-        btn_group.set_title('Button Bindings')
-        btn_group.set_description('Use the CLI (--button) to remap buttons')
-        page_box.append(btn_group)
+            groups.append(power_group)
 
-        self._btn_rows = {}
-        for btn_name, btn_id in caps.buttons.items():
-            row = Adw.ActionRow()
-            label = caps.button_labels.get(btn_name, btn_name.capitalize())
-            row.set_title(label)
-            row.set_subtitle('–')
-            btn_group.add(row)
-            self._btn_rows[btn_id] = row
+        return self._wrap_page(*groups)
 
-        # ── Reset ────────────────────────────────────────────────────────
-        if caps.has_reset:
-            reset_group = Adw.PreferencesGroup()
-            page_box.append(reset_group)
+    # ── Home tab live updates ───────────────────────────────────────────
 
-            reset_row = Adw.ButtonRow()
-            reset_row.set_title('Reset to Factory Defaults')
-            reset_row.add_css_class('destructive-action')
-            reset_row.connect('activated', self._on_reset_clicked)
-            reset_group.add(reset_row)
+    def _start_home_updates(self):
+        """Independent of the tray's own polling in PulsarMouseApp (see
+        _read_initial_state()/_hidraw_listener() there) - deliberately not
+        shared, so this window stays self-contained regardless of whether
+        a tray exists. hidraw supports multiple concurrent readers, so a
+        second listener on the same device is safe, just a bit redundant.
+        """
+        device = self._device
+        if device is None:
+            return
+        self._refresh_home_battery()
+        threading.Thread(target=self._home_hidraw_listener, daemon=True).start()
+        GLib.timeout_add_seconds(600, self._periodic_home_battery_refresh)
 
-        # ── Test Input ───────────────────────────────────────────────────
-        test_group = Adw.PreferencesGroup()
-        page_box.append(test_group)
+    def _periodic_home_battery_refresh(self):
+        self._refresh_home_battery()
+        return True
 
-        test_row = Adw.ButtonRow()
-        test_row.set_title('Test Input — click to test mouse buttons')
-        test_row.connect('activated', self._on_test_clicked)
-        test_group.add(test_row)
+    def _refresh_home_battery(self):
+        device = self._device
+        if device is None or not hasattr(device, 'get_power'):
+            return
+
+        def _read():
+            try:
+                with _USB_LOCK:
+                    device.open()
+                    try:
+                        pwr = device.get_power()
+                    finally:
+                        device.close()
+                GLib.idle_add(self._set_home_battery, pwr)
+            except Exception:
+                pass
+        threading.Thread(target=_read, daemon=True).start()
+
+    def _set_home_battery(self, pwr):
+        if self._home_battery_row is None:
+            return
+        pct = pwr['battery_percent']
+        charging = '  (charging)' if pwr['power_connected'] else ''
+        self._home_battery_row.set_subtitle(f'{pct}%{charging}')
+
+    def _home_hidraw_listener(self):
+        device = self._device
+        if device is None or not hasattr(device, 'find_hidraw'):
+            return
+        path = device.find_hidraw()
+        if not path:
+            return
+        try:
+            fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        last_update = 0.0
+        try:
+            while True:
+                data = os.read(fd, 256)
+                if not data:
+                    break
+                event = device.parse_hidraw_event(data)
+                if event and 'signal_percent' in event:
+                    now = time.monotonic()
+                    if now - last_update >= _SIGNAL_UPDATE_INTERVAL:
+                        last_update = now
+                        GLib.idle_add(self._set_home_signal, event['signal_percent'])
+        except OSError:
+            pass
+        finally:
+            os.close(fd)
+
+    def _set_home_signal(self, pct):
+        self._home_signal_row.set_subtitle(f'{pct}%  —  {_connection_quality_label(pct)}')
 
     def _make_slider_row(self, title, subtitle, lo, hi, step,
                          format_value=None, marks=None):
@@ -850,6 +1137,8 @@ class MainWindow(Adw.ApplicationWindow):
             'active':     min(self._active_stage_row.get_selected() + 1, num_stages),
             'dpi_values': [int(r.get_value()) for r in self._dpi_rows],
         }
+        if self._home_mode_row is not None:
+            self._home_mode_row.set_subtitle(f"{s['poll_hz']} Hz")
         if self._debounce_row:
             s['debounce'] = int(self._debounce_row.get_value())
         if self._angle_row:
@@ -1058,6 +1347,8 @@ class MainWindow(Adw.ApplicationWindow):
         except ValueError:
             poll_idx = len(caps.polling_rates) - 1
         self._poll_row.set_selected(poll_idx)
+        if self._home_mode_row is not None:
+            self._home_mode_row.set_subtitle(f'{poll_hz} Hz')
         if self._debounce_row and debounce is not None:
             self._debounce_row.set_value(debounce)
         if self._angle_row and angle is not None:
@@ -1276,7 +1567,7 @@ class InputTestDialog(Adw.Window):
                 if not data:
                     break
                 event = device.parse_hidraw_event(data)
-                if event:
+                if event and 'dpi' in event:
                     GLib.idle_add(self._on_dpi_event, event['dpi'], event['stage'])
         except OSError:
             pass

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -243,9 +243,18 @@ class PulsarMouseApp(Adw.Application):
             try:
                 with _USB_LOCK:
                     device.open()
-                    hz = device.get_polling_rate()
-                    dpi_info = device.get_dpi_stages(profile=1)
-                    device.close()
+                    # device.close() must run even if a getter below raises
+                    # (e.g. NotImplementedError on a partial driver like
+                    # feinmann8k.py) - otherwise the device is left open with
+                    # both interfaces claimed for the rest of the process's
+                    # life, and every later _open_dev() call fails with
+                    # "Resource busy" since nothing else can release a claim
+                    # this thread never lets go of.
+                    try:
+                        hz = device.get_polling_rate()
+                        dpi_info = device.get_dpi_stages(profile=1)
+                    finally:
+                        device.close()
                 dpi = dpi_info['stages'][dpi_info['active'] - 1][0]
                 GLib.idle_add(self._update_tray_label, dpi, hz, True)
             except Exception:

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -1600,42 +1600,42 @@ class InputTestDialog(Adw.Window):
         cr.paint()
 
         mx, my, mw, mh = w * 0.15, h * 0.02, w * 0.7, h * 0.92
-        r = mw * 0.35
         cx = mx + mw / 2
         cr.set_source_rgb(0.30, 0.30, 0.33)
-        cr.new_path()
-        # Feinmann 8K-ish silhouette: domed shoulders up top, a very mild
-        # inward taper around the grip area, and a properly rounded (not
-        # pointed) tail at the bottom - subtler than the first pass at
-        # this, which pinched/flared too aggressively and taped to a
-        # point at the back.
-        cr.move_to(cx, my)
-        cr.curve_to(mx + mw * 0.80, my,
-                    mx + mw * 0.94, my + mh * 0.04,
-                    mx + mw * 0.94, my + mh * 0.12)
-        cr.curve_to(mx + mw * 0.94, my + mh * 0.30,
-                    mx + mw * 0.90, my + mh * 0.40,
-                    mx + mw * 0.90, my + mh * 0.50)
-        cr.curve_to(mx + mw * 0.90, my + mh * 0.62,
-                    mx + mw * 0.93, my + mh * 0.72,
-                    mx + mw * 0.92, my + mh * 0.82)
-        cr.curve_to(mx + mw * 0.91, my + mh * 0.92,
-                    mx + mw * 0.75, my + mh,
-                    cx, my + mh)
-        cr.curve_to(mx + mw * 0.25, my + mh,
-                    mx + mw * 0.09, my + mh * 0.92,
-                    mx + mw * 0.08, my + mh * 0.82)
-        cr.curve_to(mx + mw * 0.07, my + mh * 0.72,
-                    mx + mw * 0.10, my + mh * 0.62,
-                    mx + mw * 0.10, my + mh * 0.50)
-        cr.curve_to(mx + mw * 0.10, my + mh * 0.40,
-                    mx + mw * 0.06, my + mh * 0.30,
-                    mx + mw * 0.06, my + mh * 0.12)
-        cr.curve_to(mx + mw * 0.06, my + mh * 0.04,
-                    mx + mw * 0.20, my,
-                    cx, my)
-        cr.close_path()
+        self._body_path(cr, mx, my, mw, mh, cx)
         cr.fill()
+
+        # Left/right click zones - drawn as persistent visible buttons
+        # (like the thumb buttons below), not just a highlight that only
+        # appears while clicked, so they read as obvious click targets.
+        # Clipped to the body outline so they follow the domed shell
+        # shape (rounded top corners etc.) instead of overflowing it as
+        # plain rectangles - rects below are sized to overshoot the body
+        # edges slightly and let the clip do the rounding. Drawn before
+        # the scroll wheel/divider so those render on top, like they
+        # physically sit above the button housings.
+        cr.save()
+        self._body_path(cr, mx, my, mw, mh, cx)
+        cr.clip()
+        lr_buttons = {1: 'L', 3: 'R'}
+        lr_zones = {
+            1: (mx, my, mw * 0.49, mh * 0.36),
+            3: (mx + mw * 0.51, my, mw * 0.49, mh * 0.36),
+        }
+        for btn_id, label in lr_buttons.items():
+            zx, zy, zw, zh = lr_zones[btn_id]
+            if self._active_btn == btn_id:
+                cr.set_source_rgb(0.3, 0.7, 1.0)
+            else:
+                cr.set_source_rgb(0.40, 0.40, 0.44)
+            self._rounded_rect(cr, zx, zy, zw, zh, 10)
+            cr.fill()
+            cr.set_source_rgb(0.9, 0.9, 0.9)
+            cr.set_font_size(12)
+            ext = cr.text_extents(label)
+            cr.move_to(zx + zw / 2 - ext.width / 2, zy + zh * 0.55)
+            cr.show_text(label)
+        cr.restore()
 
         cr.set_source_rgb(0.20, 0.20, 0.22)
         cr.set_line_width(2)
@@ -1643,7 +1643,7 @@ class InputTestDialog(Adw.Window):
         cr.line_to(w * 0.5, my + mh * 0.40)
         cr.stroke()
 
-        ww, wh = mw * 0.12, mh * 0.12
+        ww, wh = mw * 0.18, mh * 0.18
         wx = w * 0.5 - ww / 2
         wy = my + mh * 0.08
         is_scroll = isinstance(self._active_btn, str) and self._active_btn.startswith('scroll')
@@ -1693,23 +1693,6 @@ class InputTestDialog(Adw.Window):
             cr.move_to(bx + bw / 2 - ext.width / 2, by + bh / 2 + ext.height / 2)
             cr.show_text(label)
 
-        zones_on_body = {
-            1: (mx, my, mw * 0.49, mh * 0.38),
-            3: (mx + mw * 0.51, my, mw * 0.49, mh * 0.38),
-        }
-        if self._active_btn in zones_on_body:
-            zx, zy, zw, zh = zones_on_body[self._active_btn]
-            cr.set_source_rgba(0.3, 0.7, 1.0, 0.35)
-            self._rounded_rect(cr, zx, zy, zw, zh, r if self._active_btn != 3 else 6)
-            cr.fill()
-
-        cr.set_source_rgb(0.85, 0.85, 0.85)
-        cr.set_font_size(12)
-        for label, lx_frac, ly_frac in [('L', 0.38, 0.22), ('R', 0.60, 0.22)]:
-            ext = cr.text_extents(label)
-            cr.move_to(w * lx_frac - ext.width / 2, my + mh * ly_frac)
-            cr.show_text(label)
-
         dx, dy = mx + mw * 0.22, my + mh * 0.45
         dr = 7 if self._active_btn == 'dpi' else 5
         if self._active_btn == 'dpi':
@@ -1723,6 +1706,39 @@ class InputTestDialog(Adw.Window):
         ext = cr.text_extents('DPI')
         cr.move_to(dx - ext.width / 2, dy + dr + ext.height + 2)
         cr.show_text('DPI')
+
+    @staticmethod
+    def _body_path(cr, mx, my, mw, mh, cx):
+        """Traces the mouse body silhouette without filling it - shared
+        by the body fill and the L/R button clip so both use the exact
+        same outline (see _draw())."""
+        cr.new_path()
+        cr.move_to(cx, my)
+        cr.curve_to(mx + mw * 0.80, my,
+                    mx + mw * 0.94, my + mh * 0.04,
+                    mx + mw * 0.94, my + mh * 0.12)
+        cr.curve_to(mx + mw * 0.94, my + mh * 0.30,
+                    mx + mw * 0.90, my + mh * 0.40,
+                    mx + mw * 0.90, my + mh * 0.50)
+        cr.curve_to(mx + mw * 0.90, my + mh * 0.62,
+                    mx + mw * 0.93, my + mh * 0.72,
+                    mx + mw * 0.92, my + mh * 0.82)
+        cr.curve_to(mx + mw * 0.91, my + mh * 0.92,
+                    mx + mw * 0.75, my + mh,
+                    cx, my + mh)
+        cr.curve_to(mx + mw * 0.25, my + mh,
+                    mx + mw * 0.09, my + mh * 0.92,
+                    mx + mw * 0.08, my + mh * 0.82)
+        cr.curve_to(mx + mw * 0.07, my + mh * 0.72,
+                    mx + mw * 0.10, my + mh * 0.62,
+                    mx + mw * 0.10, my + mh * 0.50)
+        cr.curve_to(mx + mw * 0.10, my + mh * 0.40,
+                    mx + mw * 0.06, my + mh * 0.30,
+                    mx + mw * 0.06, my + mh * 0.12)
+        cr.curve_to(mx + mw * 0.06, my + mh * 0.04,
+                    mx + mw * 0.20, my,
+                    cx, my)
+        cr.close_path()
 
     @staticmethod
     def _rounded_rect(cr, x, y, w, h, r):

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -14,6 +14,7 @@ The system-tray icon requires the GNOME AppIndicator extension:
 
 import sys
 import os
+import json
 import struct
 import threading
 import time
@@ -437,32 +438,6 @@ class PulsarMouseApp(Adw.Application):
             self._sni.set_label('', '')
         return False
 
-    _AUTOSTART_PATH = os.path.expanduser('~/.config/autostart/pulsar-mouse.desktop')
-    _AUTOSTART_CONTENT = """\
-[Desktop Entry]
-Name=Pulsar Mouse
-Comment=Pulsar Mouse system-tray applet
-Exec=pulsar-mouse-gui
-Icon=input-mouse
-Type=Application
-X-GNOME-Autostart-enabled=true
-"""
-
-    def _autostart_enabled(self):
-        return os.path.exists(self._AUTOSTART_PATH)
-
-    def _set_autostart(self, enabled):
-        if enabled:
-            os.makedirs(os.path.dirname(self._AUTOSTART_PATH), exist_ok=True)
-            with open(self._AUTOSTART_PATH, 'w') as f:
-                f.write(self._AUTOSTART_CONTENT)
-        else:
-            os.remove(self._AUTOSTART_PATH)
-
-    def _on_autostart_row_toggled(self, row, _pspec):
-        if row.get_active() != self._autostart_enabled():
-            self._set_autostart(row.get_active())
-
     def _set_dpi(self, dpi_val: int):
         device = self._device
 
@@ -569,7 +544,7 @@ class MainWindow(Adw.ApplicationWindow):
             nav_list.append(row)
         nav_list.connect('row-selected', self._on_nav_row_selected)
         sidebar_toolbar.set_content(nav_list)
-        sidebar_page = Adw.NavigationPage.new(sidebar_toolbar, caps.name)
+        sidebar_page = Adw.NavigationPage.new(sidebar_toolbar, 'Pulsar Mouse')
         split_view.set_sidebar(sidebar_page)
 
         # ── Content: header bar (Apply/Reload/profile - shared across all
@@ -579,18 +554,6 @@ class MainWindow(Adw.ApplicationWindow):
         content_toolbar = Adw.ToolbarView()
         content_header = Adw.HeaderBar()
 
-        if caps.num_profiles > 1:
-            profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-            profile_box.append(Gtk.Label(label='Profile:'))
-            self._profile_combo = Gtk.DropDown.new_from_strings(
-                [f'Profile {i}' for i in range(1, caps.num_profiles + 1)]
-            )
-            self._profile_combo.connect('notify::selected', self._on_profile_changed)
-            profile_box.append(self._profile_combo)
-            content_header.set_title_widget(profile_box)
-        else:
-            self._profile_combo = None
-
         reload_btn = Gtk.Button(icon_name='view-refresh-symbolic')
         reload_btn.set_tooltip_text('Reload from mouse')
         reload_btn.connect('clicked', lambda _: self._reload())
@@ -599,7 +562,22 @@ class MainWindow(Adw.ApplicationWindow):
         apply_btn = Gtk.Button(label='Apply')
         apply_btn.add_css_class('suggested-action')
         apply_btn.connect('clicked', lambda _: self._apply())
+        # Packed before profile_box below: pack_end's call order runs
+        # outward from the edge, so whichever widget is packed *first*
+        # ends up rightmost - this has to go first for Apply to stay the
+        # outermost element with the profile dropdown to its left.
         content_header.pack_end(apply_btn)
+
+        if caps.num_profiles > 1:
+            profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            self._profile_combo = Gtk.DropDown.new_from_strings(
+                [f'Profile {i}' for i in range(1, caps.num_profiles + 1)]
+            )
+            self._profile_combo.connect('notify::selected', self._on_profile_changed)
+            profile_box.append(self._profile_combo)
+            content_header.pack_end(profile_box)
+        else:
+            self._profile_combo = None
 
         content_toolbar.add_top_bar(content_header)
 
@@ -885,29 +863,73 @@ class MainWindow(Adw.ApplicationWindow):
         groups.append(btn_group)
         return self._wrap_page(*groups)
 
+    _AUTOSTART_PATH = os.path.expanduser('~/.config/autostart/pulsar-mouse.desktop')
+    _AUTOSTART_CONTENT = """\
+[Desktop Entry]
+Name=Pulsar Mouse
+Comment=Pulsar Mouse system-tray applet
+Exec=pulsar-mouse-gui
+Icon=input-mouse
+Type=Application
+X-GNOME-Autostart-enabled=true
+"""
+
+    def _autostart_enabled(self):
+        return os.path.exists(self._AUTOSTART_PATH)
+
+    def _set_autostart(self, enabled):
+        if enabled:
+            os.makedirs(os.path.dirname(self._AUTOSTART_PATH), exist_ok=True)
+            with open(self._AUTOSTART_PATH, 'w') as f:
+                f.write(self._AUTOSTART_CONTENT)
+        else:
+            os.remove(self._AUTOSTART_PATH)
+
+    def _on_autostart_row_toggled(self, row, _pspec):
+        if row.get_active() != self._autostart_enabled():
+            self._set_autostart(row.get_active())
+
     def _build_tools_page(self):
         caps = self._caps
-        actions_group = Adw.PreferencesGroup()
 
+        startup_group = Adw.PreferencesGroup()
         autostart_row = Adw.SwitchRow()
         autostart_row.set_title('Start on Login')
         autostart_row.set_active(self._autostart_enabled())
         autostart_row.connect('notify::active', self._on_autostart_row_toggled)
-        actions_group.add(autostart_row)
+        startup_group.add(autostart_row)
+
+        diagnostics_group = Adw.PreferencesGroup()
+        diagnostics_group.set_title('Diagnostics')
 
         test_row = Adw.ButtonRow()
         test_row.set_title('Test Input')
         test_row.connect('activated', self._on_test_clicked)
-        actions_group.add(test_row)
+        diagnostics_group.add(test_row)
 
         if caps.has_reset:
             reset_row = Adw.ButtonRow()
             reset_row.set_title('Reset to Factory Defaults')
             reset_row.add_css_class('destructive-action')
             reset_row.connect('activated', self._on_reset_clicked)
-            actions_group.add(reset_row)
+            diagnostics_group.add(reset_row)
 
-        return self._wrap_page(actions_group)
+        io_group = Adw.PreferencesGroup()
+        io_group.set_title('Profile Import / Export')
+        io_group.set_description(
+            'Save the current profile\'s settings to a JSON file, or load them from one')
+
+        export_row = Adw.ButtonRow()
+        export_row.set_title('Export Profile to JSON')
+        export_row.connect('activated', self._on_export_clicked)
+        io_group.add(export_row)
+
+        import_row = Adw.ButtonRow()
+        import_row.set_title('Import Profile from JSON')
+        import_row.connect('activated', self._on_import_clicked)
+        io_group.add(import_row)
+
+        return self._wrap_page(startup_group, diagnostics_group, io_group)
 
     def _build_power_page(self):
         device = self._device
@@ -1113,6 +1135,81 @@ class MainWindow(Adw.ApplicationWindow):
         if response == 'reset':
             self._run_bg(self._do_reset)
 
+    def _on_export_clicked(self, _row):
+        dialog = Gtk.FileDialog()
+        dialog.set_title('Export Profile')
+        dialog.set_initial_name(f'profile-{self._profile}.json')
+        json_filter = Gtk.FileFilter()
+        json_filter.set_name('JSON files')
+        json_filter.add_pattern('*.json')
+        filters = Gio.ListStore.new(Gtk.FileFilter)
+        filters.append(json_filter)
+        dialog.set_filters(filters)
+        dialog.save(self, None, self._on_export_finish)
+
+    def _on_export_finish(self, dialog, result):
+        try:
+            gfile = dialog.save_finish(result)
+        except GLib.Error:
+            return
+        path = gfile.get_path()
+        profile = self._profile
+
+        def _do():
+            if not self._open_dev():
+                return
+            try:
+                data = self._device.export_profile(profile)
+            finally:
+                self._close_dev()
+            with open(path, 'w') as f:
+                json.dump(data, f, indent=2)
+            GLib.idle_add(self._show_toast, f'Profile {profile} exported')
+        self._run_bg(_do)
+
+    def _on_import_clicked(self, _row):
+        dialog = Gtk.FileDialog()
+        dialog.set_title('Import Profile')
+        json_filter = Gtk.FileFilter()
+        json_filter.set_name('JSON files')
+        json_filter.add_pattern('*.json')
+        filters = Gio.ListStore.new(Gtk.FileFilter)
+        filters.append(json_filter)
+        dialog.set_filters(filters)
+        dialog.open(self, None, self._on_import_finish)
+
+    def _on_import_finish(self, dialog, result):
+        try:
+            gfile = dialog.open_finish(result)
+        except GLib.Error:
+            return
+        path = gfile.get_path()
+        profile = self._profile
+
+        def _do():
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except Exception as e:
+                GLib.idle_add(self._show_error, f'Cannot read file: {e}')
+                return
+            if data.get('format') != 'pulsar-mouse-profile':
+                GLib.idle_add(self._show_error, 'Not a valid profile file')
+                return
+            if not self._open_dev():
+                return
+            try:
+                warnings = self._device.import_profile(profile, data)
+            finally:
+                self._close_dev()
+            if warnings:
+                msg = '\n'.join(warnings)
+                GLib.idle_add(self._show_error, f'Imported with warnings:\n{msg}')
+            else:
+                GLib.idle_add(self._show_toast, f'Profile {profile} imported')
+            GLib.idle_add(self._reload_profile)
+        self._run_bg(_do)
+
     # ── Thread management ────────────────────────────────────────────────
 
     def _run_bg(self, fn):
@@ -1225,6 +1322,20 @@ class MainWindow(Adw.ApplicationWindow):
     def _do_reload_profile(self):
         if not self._open_dev():
             return
+        device = self._device
+        # Selecting a profile in the dropdown switches the mouse's live
+        # active profile, not just which profile's settings this window is
+        # showing - matches the behaviour of a physical profile button.
+        # set_active_profile() is a concrete base-class method (defaults to
+        # NotImplementedError) rather than one only some drivers define, so
+        # hasattr() can't tell support apart here - same reasoning as
+        # _read_field()'s NotImplementedError handling below.
+        try:
+            device.set_active_profile(self._profile)
+        except NotImplementedError:
+            pass
+        except Exception as e:
+            GLib.idle_add(self._show_error, f'Could not switch active profile: {e}')
         self._do_reload_profile_inner()
         self._close_dev()
 

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -45,9 +45,11 @@ _SNI_XML = """
     <property name="IconThemePath" type="s" access="read"/>
     <property name="Menu"         type="o" access="read"/>
     <property name="ItemIsMenu"   type="b" access="read"/>
+    <property name="ToolTip"      type="(sa(iiay)ss)" access="read"/>
     <signal name="NewTitle"/>
     <signal name="NewIcon"/>
     <signal name="NewStatus"><arg type="s"/></signal>
+    <signal name="NewToolTip"/>
     <signal name="XAyatanaNewLabel"><arg type="s"/><arg type="s"/></signal>
     <method name="Activate"><arg type="i" direction="in"/><arg type="i" direction="in"/></method>
     <method name="ContextMenu"><arg type="i" direction="in"/><arg type="i" direction="in"/></method>
@@ -68,6 +70,7 @@ class _StatusNotifierItem:
         self._icon_name = icon_name
         self._title     = title
         self._label     = ''
+        self._tooltip_text = ''
         self._conn      = None
         self._obj_id    = 0
         self._sni_server = None
@@ -98,6 +101,15 @@ class _StatusNotifierItem:
                 'org.kde.StatusNotifierItem', 'XAyatanaNewLabel',
                 GLib.Variant('(ss)', (label, guide)))
 
+    def set_tooltip(self, text):
+        """Native hover tooltip (StatusNotifierItem ToolTip property), as
+        opposed to set_label()'s always-visible text-next-to-icon label."""
+        self._tooltip_text = text
+        if self._conn and self._obj_id:
+            self._conn.emit_signal(
+                None, '/StatusNotifierItem',
+                'org.kde.StatusNotifierItem', 'NewToolTip', None)
+
     def set_poll_items(self, items):
         self._poll_items = items
 
@@ -122,6 +134,8 @@ class _StatusNotifierItem:
             'IconThemePath':GLib.Variant('s', ''),
             'Menu':         GLib.Variant('o', self._MENU_PATH),
             'ItemIsMenu':   GLib.Variant('b', True),
+            'ToolTip':      GLib.Variant('(sa(iiay)ss)',
+                                (self._icon_name, [], self._title, self._tooltip_text)),
         }.get(prop)
 
 
@@ -172,6 +186,17 @@ class PulsarMouseApp(Adw.Application):
         item_open.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Open Settings')
         item_open.connect('item-activated', lambda _i, _t: win.present())
         root.child_append(item_open)
+
+        self._battery_item = None
+        if hasattr(device, 'get_power'):
+            battery_item = Dbusmenu.Menuitem.new()
+            battery_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Battery: —')
+            try:
+                battery_item.property_set_bool(Dbusmenu.MENUITEM_PROP_ENABLED, False)
+            except Exception:
+                pass  # cosmetic only - fine if this binding doesn't support it
+            root.child_append(battery_item)
+            self._battery_item = battery_item
 
         sep1 = Dbusmenu.Menuitem.new()
         sep1.property_set(Dbusmenu.MENUITEM_PROP_TYPE, Dbusmenu.CLIENT_TYPES_SEPARATOR)
@@ -232,6 +257,9 @@ class PulsarMouseApp(Adw.Application):
     def _start_tray_updates(self):
         self._read_initial_state()
         threading.Thread(target=self._hidraw_listener, daemon=True).start()
+        # Battery drains slowly - a periodic background refresh is enough,
+        # no need for anything event-driven like the hidraw DPI listener.
+        GLib.timeout_add_seconds(600, self._refresh_battery)
         return False
 
     def _read_initial_state(self):
@@ -253,13 +281,52 @@ class PulsarMouseApp(Adw.Application):
                     try:
                         hz = device.get_polling_rate()
                         dpi_info = device.get_dpi_stages(profile=1)
+                        pwr = None
+                        if hasattr(device, 'get_power'):
+                            # Guarded separately from hz/dpi_info above - a
+                            # battery-read failure shouldn't also take out
+                            # the DPI/Hz label.
+                            try:
+                                pwr = device.get_power()
+                            except Exception:
+                                pass
                     finally:
                         device.close()
                 dpi = dpi_info['stages'][dpi_info['active'] - 1][0]
                 GLib.idle_add(self._update_tray_label, dpi, hz, True)
+                if pwr is not None:
+                    GLib.idle_add(self._set_battery_label, pwr)
             except Exception:
                 pass
         threading.Thread(target=_read, daemon=True).start()
+
+    def _refresh_battery(self):
+        device = self._device
+        if device is None or not hasattr(device, 'get_power') or self._battery_item is None:
+            return True  # keep the timer alive in case device/UI state changes
+
+        def _read():
+            try:
+                with _USB_LOCK:
+                    device.open()
+                    try:
+                        pwr = device.get_power()
+                    finally:
+                        device.close()
+                GLib.idle_add(self._set_battery_label, pwr)
+            except Exception:
+                pass
+        threading.Thread(target=_read, daemon=True).start()
+        return True  # repeat
+
+    def _set_battery_label(self, pwr):
+        pct = pwr['battery_percent']
+        charging = ' (charging)' if pwr['power_connected'] else ''
+        text = f'Battery: {pct}%{charging}'
+        if self._battery_item is not None:
+            self._battery_item.property_set(Dbusmenu.MENUITEM_PROP_LABEL, text)
+        if self._sni is not None:
+            self._sni.set_tooltip(text)
 
     def _hidraw_listener(self):
         device = self._device

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -289,7 +289,7 @@ class PulsarMouseApp(Adw.Application):
 
     def _build_tray(self, win: 'MainWindow', device: PulsarDevice):
         caps = device.capabilities
-        sni = _StatusNotifierItem('pulsar-mouse', 'input-mouse', caps.name)
+        sni = _StatusNotifierItem('pulsar-mouse', 'pulsar-mouse', caps.name)
         sni.set_on_activate(win.present)
         self._sni = sni
 
@@ -751,7 +751,12 @@ class MainWindow(Adw.ApplicationWindow):
         box.set_margin_start(24)
         box.set_margin_end(24)
 
-        icon = Gtk.Image.new_from_icon_name('input-mouse-symbolic')
+        # 'pulsar-mouse' is the project's own logo (data/pulsar-mouse.svg,
+        # by @Scout339), not a generic GTK theme icon - resolved via the
+        # hicolor icon theme entry the package installs it under (see
+        # flake.nix's postInstall), so this only renders correctly once
+        # actually installed, not when just running from the source tree.
+        icon = Gtk.Image.new_from_icon_name('pulsar-mouse')
         icon.set_pixel_size(96)
         icon.set_halign(Gtk.Align.CENTER)
         box.append(icon)

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -571,6 +571,7 @@ class MainWindow(Adw.ApplicationWindow):
             ('performance', 'Performance', 'preferences-system-symbolic'),
             ('customize', 'Customize', 'preferences-desktop-symbolic'),
             ('power', 'Power', 'battery-good-symbolic'),
+            ('tools', 'Tools', 'applications-utilities-symbolic'),
         ]
         for _name, label, icon in self._nav_pages:
             row = Adw.ActionRow()
@@ -634,6 +635,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._view_stack.add_named(self._build_performance_page(), 'performance')
         self._view_stack.add_named(self._build_customize_page(), 'customize')
         self._view_stack.add_named(self._build_power_page(), 'power')
+        self._view_stack.add_named(self._build_tools_page(), 'tools')
 
         content_page = Adw.NavigationPage.new(content_toolbar, 'Settings')
         split_view.set_content(content_page)
@@ -713,17 +715,6 @@ class MainWindow(Adw.ApplicationWindow):
             Gtk.Image.new_from_icon_name('network-wireless-symbolic'))
         status_group.add(self._home_mode_row)
 
-        device = self._device
-        if hasattr(device, 'get_power'):
-            self._home_battery_row = Adw.ActionRow()
-            self._home_battery_row.set_title('Battery')
-            self._home_battery_row.set_subtitle('—')
-            self._home_battery_row.add_prefix(
-                Gtk.Image.new_from_icon_name('battery-good-symbolic'))
-            status_group.add(self._home_battery_row)
-        else:
-            self._home_battery_row = None
-
         # Always shown even though we can't know in advance whether this
         # model actually pushes signal-quality events - it just stays
         # "—" harmlessly if nothing ever arrives (see
@@ -734,6 +725,17 @@ class MainWindow(Adw.ApplicationWindow):
         self._home_signal_row.add_prefix(
             Gtk.Image.new_from_icon_name('network-wireless-signal-good-symbolic'))
         status_group.add(self._home_signal_row)
+
+        device = self._device
+        if hasattr(device, 'get_power'):
+            self._home_battery_row = Adw.ActionRow()
+            self._home_battery_row.set_title('Battery')
+            self._home_battery_row.set_subtitle('—')
+            self._home_battery_row.add_prefix(
+                Gtk.Image.new_from_icon_name('battery-good-symbolic'))
+            status_group.add(self._home_battery_row)
+        else:
+            self._home_battery_row = None
 
         return box
 
@@ -888,6 +890,14 @@ class MainWindow(Adw.ApplicationWindow):
             btn_group.add(row)
             self._btn_rows[btn_id] = row
 
+        groups = []
+        if caps.has_led:
+            groups.append(led_group)
+        groups.append(btn_group)
+        return self._wrap_page(*groups)
+
+    def _build_tools_page(self):
+        caps = self._caps
         actions_group = Adw.PreferencesGroup()
 
         test_row = Adw.ButtonRow()
@@ -902,12 +912,7 @@ class MainWindow(Adw.ApplicationWindow):
             reset_row.connect('activated', self._on_reset_clicked)
             actions_group.add(reset_row)
 
-        groups = []
-        if caps.has_led:
-            groups.append(led_group)
-        groups.append(btn_group)
-        groups.append(actions_group)
-        return self._wrap_page(*groups)
+        return self._wrap_page(actions_group)
 
     def _build_power_page(self):
         device = self._device
@@ -1640,8 +1645,6 @@ class InputTestDialog(Adw.Window):
         thumb_buttons = [
             ('left',  0.38, 'FWD',  9),
             ('left',  0.52, 'BACK', 8),
-            ('right', 0.38, 'FWD',  9),
-            ('right', 0.52, 'BACK', 8),
         ]
         for side, ty, label, btn_id in thumb_buttons:
             if side == 'left':

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -878,15 +878,17 @@ class MainWindow(Adw.ApplicationWindow):
             return
         caps = self._caps
         device = self._device
-        try:
-            poll_hz = device.get_polling_rate()
-            debounce = device.get_debounce() if caps.has_debounce else None
-            angle = device.get_angle_snap() if caps.has_angle_snap else None
-            ripple = device.get_ripple_control() if caps.has_ripple_control else None
-            motion = device.get_motion_sync() if caps.has_motion_sync else None
-            GLib.idle_add(self._populate_global, poll_hz, debounce, angle, ripple, motion)
-        except Exception as e:
-            GLib.idle_add(self._show_error, f'Read error (global): {e}')
+        # Each field guarded independently via _read_field (same reasoning
+        # as _do_reload_profile_inner() below) - a reload is 20+ individual
+        # USB reads in quick succession, and a transient timeout on any one
+        # of them (mouse's RF link briefly asleep) shouldn't blank out
+        # every other already-successful field, including these.
+        poll_hz = self._read_field(device.get_polling_rate)
+        debounce = self._read_field(device.get_debounce) if caps.has_debounce else None
+        angle = self._read_field(device.get_angle_snap) if caps.has_angle_snap else None
+        ripple = self._read_field(device.get_ripple_control) if caps.has_ripple_control else None
+        motion = self._read_field(device.get_motion_sync) if caps.has_motion_sync else None
+        GLib.idle_add(self._populate_global, poll_hz, debounce, angle, ripple, motion)
         self._do_reload_profile_inner()
         self._close_dev()
 
@@ -899,10 +901,16 @@ class MainWindow(Adw.ApplicationWindow):
     def _read_field(self, fn, *args):
         # Drivers may only implement a subset of get_* methods (e.g. a
         # write-only-so-far driver like feinmann8k.py) - one missing getter
-        # shouldn't block every other field from loading.
+        # shouldn't block every other field from loading. Also covers a
+        # read that times out (raises IOError/OSError - see
+        # feinmann8k.py's _query_ctrl()) because the mouse's RF link
+        # happened to be asleep for that one field: a reload can involve
+        # 20+ individual reads in quick succession, so hitting a transient
+        # timeout on any single one of them is expected, not exceptional -
+        # it shouldn't blank out every other already-successful field.
         try:
             return fn(*args)
-        except NotImplementedError:
+        except (NotImplementedError, OSError):
             return None
 
     def _do_reload_profile_inner(self):
@@ -916,13 +924,13 @@ class MainWindow(Adw.ApplicationWindow):
             breath = (self._read_field(device.get_breath_speed, p)
                       if caps.has_led and caps.has_breath_speed else None)
             try:
-                # NOTE: on drivers like feinmann8k.py, get_dpi_stages() is
-                # known to mutate the device's active DPI stage as a side
-                # effect of reading it (see that driver's docstring) - every
+                # NOTE: on some drivers, get_dpi_stages() is known to
+                # mutate the device's active DPI stage as a side effect of
+                # reading it (see that driver's docstring, if so) - every
                 # reload here can silently change what the user thinks is
                 # selected. Not fixed here; tracked as a driver-level issue.
                 dpi_info = device.get_dpi_stages(p)
-            except NotImplementedError:
+            except (NotImplementedError, OSError):
                 dpi_info = {'active': -1, 'count': caps.max_dpi_stages, 'stages': []}
             colors = None
             if caps.has_stage_colors:

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -1601,12 +1601,39 @@ class InputTestDialog(Adw.Window):
 
         mx, my, mw, mh = w * 0.15, h * 0.02, w * 0.7, h * 0.92
         r = mw * 0.35
+        cx = mx + mw / 2
         cr.set_source_rgb(0.30, 0.30, 0.33)
         cr.new_path()
-        cr.arc(mx + r, my + r, r, math.pi, 1.5 * math.pi)
-        cr.arc(mx + mw - r, my + r, r, 1.5 * math.pi, 2 * math.pi)
-        cr.arc(mx + mw - r, my + mh - r, r, 0, 0.5 * math.pi)
-        cr.arc(mx + r, my + mh - r, r, 0.5 * math.pi, math.pi)
+        # Feinmann 8K-ish silhouette: domed shoulders up top, a very mild
+        # inward taper around the grip area, and a properly rounded (not
+        # pointed) tail at the bottom - subtler than the first pass at
+        # this, which pinched/flared too aggressively and taped to a
+        # point at the back.
+        cr.move_to(cx, my)
+        cr.curve_to(mx + mw * 0.80, my,
+                    mx + mw * 0.94, my + mh * 0.04,
+                    mx + mw * 0.94, my + mh * 0.12)
+        cr.curve_to(mx + mw * 0.94, my + mh * 0.30,
+                    mx + mw * 0.90, my + mh * 0.40,
+                    mx + mw * 0.90, my + mh * 0.50)
+        cr.curve_to(mx + mw * 0.90, my + mh * 0.62,
+                    mx + mw * 0.93, my + mh * 0.72,
+                    mx + mw * 0.92, my + mh * 0.82)
+        cr.curve_to(mx + mw * 0.91, my + mh * 0.92,
+                    mx + mw * 0.75, my + mh,
+                    cx, my + mh)
+        cr.curve_to(mx + mw * 0.25, my + mh,
+                    mx + mw * 0.09, my + mh * 0.92,
+                    mx + mw * 0.08, my + mh * 0.82)
+        cr.curve_to(mx + mw * 0.07, my + mh * 0.72,
+                    mx + mw * 0.10, my + mh * 0.62,
+                    mx + mw * 0.10, my + mh * 0.50)
+        cr.curve_to(mx + mw * 0.10, my + mh * 0.40,
+                    mx + mw * 0.06, my + mh * 0.30,
+                    mx + mw * 0.06, my + mh * 0.12)
+        cr.curve_to(mx + mw * 0.06, my + mh * 0.04,
+                    mx + mw * 0.20, my,
+                    cx, my)
         cr.close_path()
         cr.fill()
 
@@ -1683,7 +1710,7 @@ class InputTestDialog(Adw.Window):
             cr.move_to(w * lx_frac - ext.width / 2, my + mh * ly_frac)
             cr.show_text(label)
 
-        dx, dy = w * 0.5, my + mh * 0.28
+        dx, dy = mx + mw * 0.22, my + mh * 0.45
         dr = 7 if self._active_btn == 'dpi' else 5
         if self._active_btn == 'dpi':
             cr.set_source_rgb(0.3, 0.7, 1.0)

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -269,17 +269,6 @@ class PulsarMouseApp(Adw.Application):
         sep2.property_set(Dbusmenu.MENUITEM_PROP_TYPE, Dbusmenu.CLIENT_TYPES_SEPARATOR)
         root.child_append(sep2)
 
-        item_auto = Dbusmenu.Menuitem.new()
-        item_auto.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Start on Login')
-        item_auto.property_set(Dbusmenu.MENUITEM_PROP_TOGGLE_TYPE,
-                               Dbusmenu.MENUITEM_TOGGLE_CHECK)
-        item_auto.property_set_int(Dbusmenu.MENUITEM_PROP_TOGGLE_STATE,
-                                   Dbusmenu.MENUITEM_TOGGLE_STATE_CHECKED
-                                   if self._autostart_enabled() else
-                                   Dbusmenu.MENUITEM_TOGGLE_STATE_UNCHECKED)
-        item_auto.connect('item-activated', lambda _i, _t: self._toggle_autostart(_i))
-        root.child_append(item_auto)
-
         item_quit = Dbusmenu.Menuitem.new()
         item_quit.property_set(Dbusmenu.MENUITEM_PROP_LABEL, 'Quit')
         item_quit.connect('item-activated', lambda _i, _t: self.quit())
@@ -462,17 +451,17 @@ X-GNOME-Autostart-enabled=true
     def _autostart_enabled(self):
         return os.path.exists(self._AUTOSTART_PATH)
 
-    def _toggle_autostart(self, menu_item):
-        if self._autostart_enabled():
-            os.remove(self._AUTOSTART_PATH)
-            menu_item.property_set_int(Dbusmenu.MENUITEM_PROP_TOGGLE_STATE,
-                                       Dbusmenu.MENUITEM_TOGGLE_STATE_UNCHECKED)
-        else:
+    def _set_autostart(self, enabled):
+        if enabled:
             os.makedirs(os.path.dirname(self._AUTOSTART_PATH), exist_ok=True)
             with open(self._AUTOSTART_PATH, 'w') as f:
                 f.write(self._AUTOSTART_CONTENT)
-            menu_item.property_set_int(Dbusmenu.MENUITEM_PROP_TOGGLE_STATE,
-                                       Dbusmenu.MENUITEM_TOGGLE_STATE_CHECKED)
+        else:
+            os.remove(self._AUTOSTART_PATH)
+
+    def _on_autostart_row_toggled(self, row, _pspec):
+        if row.get_active() != self._autostart_enabled():
+            self._set_autostart(row.get_active())
 
     def _set_dpi(self, dpi_val: int):
         device = self._device
@@ -568,7 +557,7 @@ class MainWindow(Adw.ApplicationWindow):
         # nav_list's row index in _on_nav_row_selected() below.
         self._nav_pages = [
             ('home', 'Home', 'go-home-symbolic'),
-            ('performance', 'Performance', 'preferences-system-symbolic'),
+            ('performance', 'Performance', 'input-mouse-symbolic'),
             ('customize', 'Customize', 'preferences-desktop-symbolic'),
             ('power', 'Power', 'battery-good-symbolic'),
             ('tools', 'Tools', 'applications-utilities-symbolic'),
@@ -872,7 +861,7 @@ class MainWindow(Adw.ApplicationWindow):
         if caps.has_led and caps.has_breath_speed:
             lo, hi = caps.breath_speed_range
             self._breath_row_container, self._breath_row = self._make_slider_row(
-                'Breath Speed', '', lo, hi, 1,
+                'Pulse Speed', '', lo, hi, 1,
                 marks=[(lo, 'Slow'), (hi, 'Fast')])
             self._breath_row_container.set_visible(False)
             led_group.add(self._breath_row_container)
@@ -900,8 +889,14 @@ class MainWindow(Adw.ApplicationWindow):
         caps = self._caps
         actions_group = Adw.PreferencesGroup()
 
+        autostart_row = Adw.SwitchRow()
+        autostart_row.set_title('Start on Login')
+        autostart_row.set_active(self._autostart_enabled())
+        autostart_row.connect('notify::active', self._on_autostart_row_toggled)
+        actions_group.add(autostart_row)
+
         test_row = Adw.ButtonRow()
-        test_row.set_title('Test Input — click to test mouse buttons')
+        test_row.set_title('Test Input')
         test_row.connect('activated', self._on_test_clicked)
         actions_group.add(test_row)
 

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -22,7 +22,7 @@ import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 gi.require_version('Dbusmenu', '0.4')
-from gi.repository import Gtk, Adw, GLib, Gio, Dbusmenu
+from gi.repository import Gtk, Adw, GLib, Gio, Gdk, Dbusmenu
 
 from pulsar_mouse import find_device, scan_devices, __version__
 from pulsar_mouse.base import PulsarDevice, DeviceCapabilities
@@ -571,9 +571,17 @@ class MainWindow(Adw.ApplicationWindow):
         dpi_group.add(self._active_stage_row)
 
         self._dpi_rows = []
+        self._color_buttons = []
         for i in range(1, caps.max_dpi_stages + 1):
             row = Adw.SpinRow.new_with_range(caps.dpi_min, caps.dpi_max, caps.dpi_step)
             row.set_title(f'Stage {i}')
+            if caps.has_stage_colors:
+                color_btn = Gtk.ColorDialogButton(dialog=Gtk.ColorDialog())
+                color_btn.set_rgba(Gdk.RGBA(red=1.0, green=1.0, blue=1.0, alpha=1.0))
+                color_btn.set_valign(Gtk.Align.CENTER)
+                color_btn.set_tooltip_text(f'Stage {i} LED color')
+                row.add_suffix(color_btn)
+                self._color_buttons.append(color_btn)
             dpi_group.add(row)
             self._dpi_rows.append(row)
 
@@ -752,6 +760,12 @@ class MainWindow(Adw.ApplicationWindow):
             s['led'] = caps.led_effects[self._led_row.get_selected()]
         if self._breath_row:
             s['breath'] = int(self._breath_row.get_value())
+        if self._color_buttons:
+            colors = []
+            for btn in self._color_buttons:
+                rgba = btn.get_rgba()
+                colors.append((round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255)))
+            s['colors'] = colors
         self._run_bg(lambda: self._do_apply(s))
 
     # ── USB workers (run in background threads) ──────────────────────────
@@ -806,20 +820,42 @@ class MainWindow(Adw.ApplicationWindow):
         self._do_reload_profile_inner()
         self._close_dev()
 
+    def _read_field(self, fn, *args):
+        # Drivers may only implement a subset of get_* methods (e.g. a
+        # write-only-so-far driver like feinmann8k.py) - one missing getter
+        # shouldn't block every other field from loading.
+        try:
+            return fn(*args)
+        except NotImplementedError:
+            return None
+
     def _do_reload_profile_inner(self):
         caps = self._caps
         device = self._device
         p = self._profile
         try:
-            lod = device.get_lod(p) if caps.lod_values else None
-            brightness = device.get_brightness(p) if caps.has_led else None
-            led = device.get_led_effect(p) if caps.has_led else None
-            breath = device.get_breath_speed(p) if caps.has_led and caps.has_breath_speed else None
-            dpi_info = device.get_dpi_stages(p)
-            buttons = {bid: device.get_button(bid, p)
+            lod = self._read_field(device.get_lod, p) if caps.lod_values else None
+            brightness = self._read_field(device.get_brightness, p) if caps.has_led else None
+            led = self._read_field(device.get_led_effect, p) if caps.has_led else None
+            breath = (self._read_field(device.get_breath_speed, p)
+                      if caps.has_led and caps.has_breath_speed else None)
+            try:
+                # NOTE: on drivers like feinmann8k.py, get_dpi_stages() is
+                # known to mutate the device's active DPI stage as a side
+                # effect of reading it (see that driver's docstring) - every
+                # reload here can silently change what the user thinks is
+                # selected. Not fixed here; tracked as a driver-level issue.
+                dpi_info = device.get_dpi_stages(p)
+            except NotImplementedError:
+                dpi_info = {'active': -1, 'count': caps.max_dpi_stages, 'stages': []}
+            colors = None
+            if caps.has_stage_colors:
+                colors = [self._read_field(device.get_stage_color, i, p)
+                         for i in range(1, caps.max_dpi_stages + 1)]
+            buttons = {bid: self._read_field(device.get_button, bid, p)
                        for bid in caps.buttons.values()}
             GLib.idle_add(self._populate_profile,
-                          lod, brightness, led, breath, dpi_info, buttons)
+                          lod, brightness, led, breath, dpi_info, colors, buttons)
         except Exception as e:
             GLib.idle_add(self._show_error, f'Read error (profile {p}): {e}')
 
@@ -850,7 +886,17 @@ class MainWindow(Adw.ApplicationWindow):
                     device.set_breath_speed(s['breath'], p)
 
             stages = s['dpi_values'][:s['num_stages']]
-            device.set_dpi_stages(stages, s['active'], p)
+            try:
+                device.set_dpi_stages(stages, s['active'], p)
+            except NotImplementedError:
+                # Per-stage DPI values aren't writable on this driver yet -
+                # still apply the active-stage selection on its own so that
+                # part of the DPI Stages section isn't silently a no-op.
+                device.set_active_dpi_stage(s['active'], p)
+
+            if 'colors' in s:
+                for i, (r, g, b) in enumerate(s['colors'][:s['num_stages']], start=1):
+                    device.set_stage_color(i, r, g, b, p)
 
             GLib.idle_add(self._show_toast, 'Settings applied')
         except Exception as e:
@@ -890,7 +936,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._motion_row.set_active(motion)
         self._building = False
 
-    def _populate_profile(self, lod, brightness, led, breath, dpi_info, buttons):
+    def _populate_profile(self, lod, brightness, led, breath, dpi_info, colors, buttons):
         caps = self._caps
         self._building = True
         if self._lod_row and lod is not None:
@@ -921,8 +967,17 @@ class MainWindow(Adw.ApplicationWindow):
             row.set_value(stages[i][0] if i < len(stages) else 800)
             row.set_sensitive(i < num)
 
-        for btn_id, (t, a1, a2) in buttons.items():
-            if btn_id in self._btn_rows:
+        if self._color_buttons and colors:
+            for i, btn in enumerate(self._color_buttons):
+                rgb = colors[i] if i < len(colors) else None
+                if rgb is not None:
+                    r, g, b = rgb
+                    btn.set_rgba(Gdk.RGBA(red=r / 255, green=g / 255, blue=b / 255, alpha=1.0))
+                btn.set_sensitive(i < num)
+
+        for btn_id, bind in buttons.items():
+            if bind is not None and btn_id in self._btn_rows:
+                t, a1, a2 = bind
                 self._btn_rows[btn_id].set_subtitle(describe_button(t, a1, a2))
         self._building = False
 

--- a/src/pulsar_mouse/hid.py
+++ b/src/pulsar_mouse/hid.py
@@ -8,6 +8,7 @@ and shared across all drivers.
 
 # ── Button function types ────────────────────────────────────────────────────
 
+BTN_TYPE_DISABLED  = 0x00   # button disabled (no action)
 BTN_TYPE_MOUSE     = 0x01   # standard mouse click
 BTN_TYPE_KEYBOARD  = 0x02   # keyboard shortcut
 BTN_TYPE_SCROLL    = 0x03   # scroll wheel
@@ -86,6 +87,8 @@ HID_KEYS = {**_alpha, **_digits, **_special}
 
 def describe_button(btn_type: int, a1: int, a2: int) -> str:
     """Human-readable description of a button binding."""
+    if btn_type == BTN_TYPE_DISABLED:
+        return 'disabled'
     if btn_type == BTN_TYPE_MOUSE:
         return MOUSE_ACTION_NAMES.get(a1, f'mouse(0x{a1:02x})')
     if btn_type == BTN_TYPE_KEYBOARD:
@@ -122,9 +125,12 @@ def parse_button_function(spec: str) -> tuple[int, int, int]:
       xclick
       play / next / prev / stop / mute / vol+ / vol- / mediaplayer
       ctrl+c / shift+f5 / alt+tab / ...  (keyboard shortcut)
+      disabled
     """
     s = spec.strip().lower()
 
+    if s == 'disabled':
+        return (BTN_TYPE_DISABLED, 0x00, 0x00)
     if s in MOUSE_ACTIONS:
         return (BTN_TYPE_MOUSE, MOUSE_ACTIONS[s], 0x00)
     if s in SCROLL_ACTIONS:

--- a/udev/50-pulsar-mouse.rules
+++ b/udev/50-pulsar-mouse.rules
@@ -1,6 +1,10 @@
 # udev rules for Pulsar gaming mice
-# Grants device access to the logged-in user (via TAG+="uaccess") and
-# to members of the 'plugdev' group as a fallback.
+# Grants device access to the logged-in seat user via TAG+="uaccess"
+# (systemd-logind ACL - no group needed). MODE="0660" is a fallback for
+# non-logind setups. Deliberately no GROUP="plugdev": many modern distros
+# (including stock NixOS) don't create that group, and udev treats a rule
+# referencing an unresolvable group as invalid *in its entirety* - MODE and
+# TAG on the same line silently stop applying too, not just GROUP.
 #
 # Install:
 #   sudo cp udev/50-pulsar-mouse.rules /etc/udev/rules.d/
@@ -8,23 +12,23 @@
 #   (then re-plug the mouse or reboot)
 
 # Pulsar X2A Medium Wired (VID 0x3710, PID 0x1404)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1404", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1404", MODE="0660", TAG+="uaccess"
 
 # Pulsar X2H Wired Medium (VID 0x3710, PID 0x1403)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660", TAG+="uaccess"
 
 # Pulsar Xlite v4 (VID 0x3710, PID 0x3401)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", TAG+="uaccess"
 
 # Pulsar Feinmann 8K Dongle (VID 0x3710, PID 0x5404)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", TAG+="uaccess"
 
 # Pulsar Nordic chipset — X2A Wireless, X2 V2 Mini (VID 0x3554)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f507", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f508", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f507", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f508", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f507", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f508", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f507", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f508", MODE="0660", TAG+="uaccess"

--- a/udev/50-pulsar-mouse.rules
+++ b/udev/50-pulsar-mouse.rules
@@ -19,6 +19,10 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 
+# Pulsar Feinmann 8K Dongle (VID 0x3710, PID 0x5404)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+
 # Pulsar Nordic chipset — X2A Wireless, X2 V2 Mini (VID 0x3554)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f507", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3554", ATTRS{idProduct}=="f508", MODE="0660", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
## Summary

Adds full support for the Pulsar Feinmann 8K wireless dongle (marketed as the "Feinmann FO1"), reverse-engineered from scratch via a Wireshark/USBPcap capture of Fusion on Windows and live-verified against real hardware, plus a substantial round of GUI features and reliability fixes built out on top of it.

### New device: Feinmann 8K / FO1
- Full protocol implementation: polling rate, debounce, angle snap, ripple control, motion sync, LOD (0.7–2.0mm in 0.1mm steps, live-verified across the full range), DPI stages, per-stage LED colors, LED effect/brightness/breath speed, button bindings, battery, wireless power management
- **6 onboard profiles** - the initial capture only ever showed profile byte `0x01`, so `num_profiles` was set to 1; live-probing found profiles 1–6 all ACK with correctly echoed profile bytes and stable per-slot data, while 7+ time out. Also fixed six per-profile setters that were hardcoding the profile byte to `0x01` regardless of which profile was requested.
- **Active profile get/set** - shares X2A's exact command (`cat=0x02/reg=0x06/sub=0x01`); confirmed via a live switch-and-restore round trip. Wired into the GUI's profile dropdown so selecting a profile actually switches the mouse's live active profile, not just which one is shown for editing.
- udev rule for the dongle (VID `0x3710`, PID `0x5404`), no `plugdev` group dependency (uaccess only)
- Root-caused a "dead echo" issue in the read-flavored query polling loop: the device needs a live RF round-trip before its GET_REPORT reply is real, not immediate - the first poll's `byte[0]=0x02` means "not ready yet," not permanent failure

### GUI redesign
- Tabbed navigation (Home / Performance / Customize / Power / Tools) replacing the single long page, with a live status Home page (model, firmware version, connection type, polling rate, DPI, signal quality, battery)
- Button remapping: click a row in Button Bindings, pick from Mouse Click / Scroll / DPI / Profile Switch / Media Key / Keyboard Shortcut / Disabled dropdowns, applies immediately
- Profile import/export to JSON (CLI `--export`/`--import` flags and GUI buttons)
- Desktop pointer-settings integration (Acceleration Profile, Speed/Sensitivity) for GNOME, Hyprland, and KDE Plasma, each gated on actually detecting that environment
- Test Input dialog diagram is now data-driven from `capabilities.buttons` (correctly renders X2A's 4 thumb buttons, omits DPI for devices like the Nordic that don't have one) instead of assuming every device has the same fixed button layout
- Sliders (Wireless Power Saving, Low Power Mode) now snap to clean increments while dragging instead of landing on arbitrary values
- Wired/wireless is now detected via `hasattr(device, 'get_power')` rather than `find_hidraw`, which has a base-class default and was therefore true for every driver regardless of actual wireless capability - this was silently showing Battery/Connection Quality UI for wired devices

### Reliability / correctness fixes (apply beyond just the new driver)
- Fixed a crash that broke every GUI launch on `main`: the Tools tab's "Start on Login" toggle called autostart methods still defined on `PulsarMouseApp` instead of `MainWindow` after the tabbed redesign - GLib swallows exceptions from signal handlers silently, so the app looked launched (exit 0, no window) with nothing indicating why
- Fixed a USB handle leak causing "Resource busy" on every `open()` after the first
- Fixed writes silently dropping each other when fired back-to-back
- `cli.py`: fixed falsy-zero values (`--debounce 0`, `--brightness 0`, etc.) being treated as omitted flags

### Packaging
- Added `flake.nix` so the project can be consumed directly (`nix run github:packerlschupfer/pulsar-mouse-linux`, or as a flake input/overlay) instead of requiring a consumer to duplicate the derivation themselves

## Notes for review

- This branch was based on an earlier point in `main` and hasn't been rebased onto the latest `main` (which has since added its own active-profile/profile-import-export/device-info work) - there's likely some overlap to reconcile, happy to rebase and resolve conflicts if that's preferred over merging as-is.
- The GUI changes are large; happy to split into smaller PRs if that's easier to review.

## Test plan

- [x] Live-verified against real Feinmann FO1 hardware throughout (protocol reads/writes, profile switching, LOD range, button remapping, import/export round-trip)
- [x] Verified diagram/button-set changes don't break other drivers by instantiating X2A and Nordic driver classes directly and rendering
- [x] Full `nixos-rebuild build` + launch against real hardware after the flake packaging change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>