### PR TITLE
Add Xlite v4 wireless dongle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Wireless (Nordic) protocol based on [python-pulsar-mouse-tool](https://github.co
 | Pulsar X2H Wired Medium | `x2h` | `3710:1403` | Fully supported |
 | Pulsar X2A Medium Wired | `x2a` | `3710:1404` | Fully supported |
 | Pulsar Xlite v4 | `xlite_v4` | `3710:3401` | Untested (same Sonix protocol) |
+| Pulsar Xlite v4 Wireless | `xlite_v4_wireless` | `3710:5402` | Supported (1K wireless dongle, same Sonix protocol) |
 | Pulsar Feinmann 8K / FO1 | `feinmann8k` | `3710:5404` | Fully supported (wireless dongle, 8K Hz polling, 6 onboard profiles) |
 | Pulsar X2A Wireless / X2 V2 Mini | `nordic` | `3554:f507` `3554:f508` | Supported (Nordic chipset, battery status) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ x2h = "pulsar_mouse.drivers.x2h:PulsarX2H"
 x2_wired = "pulsar_mouse.drivers.x2_wired:PulsarX2Wired"
 xlite_v4 = "pulsar_mouse.drivers.xlite_v4:PulsarXliteV4"
 xlite_wired = "pulsar_mouse.drivers.xlite_wired:PulsarXliteWired"
+xlite_v4_wireless = "pulsar_mouse.drivers.xlite_v4_wireless:PulsarXliteV4Wireless"
 feinmann8k = "pulsar_mouse.drivers.feinmann8k:PulsarFeinmann8K"
 nordic = "pulsar_mouse.drivers.nordic:PulsarNordic"
 

--- a/src/pulsar_mouse/drivers/xlite_v4_wireless.py
+++ b/src/pulsar_mouse/drivers/xlite_v4_wireless.py
@@ -11,10 +11,10 @@ USB:
 """
 
 from pulsar_mouse.base import DeviceCapabilities
-from pulsar_mouse.drivers.x2a import PulsarX2A
+from pulsar_mouse.drivers.xlite_v4 import PulsarXliteV4
 
 
-class PulsarXliteV4Wireless(PulsarX2A):
+class PulsarXliteV4Wireless(PulsarXliteV4):
     """Driver for the Pulsar Xlite v4 through its 1K wireless dongle."""
 
     capabilities: DeviceCapabilities = DeviceCapabilities(

--- a/src/pulsar_mouse/drivers/xlite_v4_wireless.py
+++ b/src/pulsar_mouse/drivers/xlite_v4_wireless.py
@@ -1,0 +1,48 @@
+"""
+Pulsar Xlite v4 Wireless — protocol driver.
+
+The Xlite v4 1K wireless dongle uses the same 64-byte HID Feature
+Report protocol as the existing X2A/Xlite v4 implementation.
+
+USB:
+    VID 0x3710
+    PID 0x5402
+    Interface 3
+"""
+
+from pulsar_mouse.base import DeviceCapabilities
+from pulsar_mouse.drivers.x2a import PulsarX2A
+
+
+class PulsarXliteV4Wireless(PulsarX2A):
+    """Driver for the Pulsar Xlite v4 through its 1K wireless dongle."""
+
+    capabilities: DeviceCapabilities = DeviceCapabilities(
+        name='Pulsar Xlite v4 Wireless',
+        vid_pid_pairs=[(0x3710, 0x5402)],
+        interface_num=3,
+        report_size=64,
+        num_profiles=5,
+        max_dpi_stages=6,
+        dpi_min=100,
+        dpi_max=26000,
+        dpi_step=100,
+        buttons={
+            'left':   0x01,
+            'right':  0x02,
+            'wheel':  0x03,
+            'thumb1': 0x04,
+            'thumb2': 0x05,
+            'dpi':    0x0b,
+        },
+        polling_rates=[125, 250, 500, 1000],
+        lod_values=[1, 2],
+        button_labels={
+            'left': 'Left Click',
+            'right': 'Right Click',
+            'wheel': 'Wheel Click',
+            'thumb1': 'Side Front (forward)',
+            'thumb2': 'Side Back (backward)',
+            'dpi': 'DPI Button',
+        },
+    )

--- a/udev/50-pulsar-mouse.rules
+++ b/udev/50-pulsar-mouse.rules
@@ -31,6 +31,10 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="1403", MODE="0660
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="3401", MODE="0660", TAG+="uaccess"
 
+# Pulsar Xlite v4 1K Dongle (VID 0x3710, PID 0x5402)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5402", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5402", MODE="0660", TAG+="uaccess"
+
 # Pulsar Feinmann 8K Dongle (VID 0x3710, PID 0x5404)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", ATTRS{idVendor}=="3710", ATTRS{idProduct}=="5404", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Adds support for Xlite v4 over the 1K dongle (`3710:5402`) by reusing the existing protocol code.

Changes:
- new driver
- `pyproject.toml` entry point
- udev rule
- README row

Tested on my own mouse/dongle:
- detected in CLI and GUI
- reads settings
- can change settings 