### PR TITLE
Add thumb3, thumb4, and DPI button support for Pulsar X2A Wireless

### DIFF
--- a/src/pulsar_mouse/drivers/nordic.py
+++ b/src/pulsar_mouse/drivers/nordic.py
@@ -81,9 +81,11 @@ BUTTON_ADDRS = {
     'left':    0x60,
     'right':   0x64,
     'wheel':   0x68,
-    # Xlite V3: physical top = 0x70, bottom = 0x6C (andrewrabert FORWARD/BACK).
-    'thumb1':  0x70,   # side top / front
-    'thumb2':  0x6C,   # side bottom / back
+    'thumb2':  0x6C,   # left side bottom / back (backward)
+    'thumb1':  0x70,   # left side top / front (forward)
+    'dpi':     0x74,   # DPI button
+    'thumb4':  0x78,   # right side back (backward)
+    'thumb3':  0x7C,   # right side front (forward)
 }
 
 ADDR_DEBOUNCE         = 0xA9
@@ -273,8 +275,11 @@ class PulsarNordic(PulsarDevice):
             'left':    0x01,
             'right':   0x02,
             'wheel':   0x03,
-            'thumb1':  0x04,   # side front (forward)
-            'thumb2':  0x05,   # side back  (backward)
+            'thumb1':  0x04,   # left side front (forward)
+            'thumb2':  0x05,   # left side back  (backward)
+            'thumb3':  0x06,   # right side front (forward)
+            'thumb4':  0x07,   # right side back  (backward)
+            'dpi':     0x0b,   # DPI button
         },
         polling_rates=[125, 250, 500, 1000],
         lod_values=[1, 2],
@@ -285,7 +290,9 @@ class PulsarNordic(PulsarDevice):
         button_labels={
             'left': 'Left Click', 'right': 'Right Click',
             'wheel': 'Wheel Click',
-            'thumb1': 'Side Top (front)', 'thumb2': 'Side Bottom (back)',
+            'thumb1': 'Thumb 1 (forward)', 'thumb2': 'Thumb 2 (back)',
+            'thumb3': 'Thumb 3 (forward)', 'thumb4': 'Thumb 4 (back)',
+            'dpi': 'DPI Button',
         },
     )
 

--- a/src/pulsar_mouse/gui.py
+++ b/src/pulsar_mouse/gui.py
@@ -48,7 +48,7 @@ from pulsar_mouse.base import PulsarDevice, DeviceCapabilities
 from pulsar_mouse.drivers import discover_all
 from pulsar_mouse.hid import (
     describe_button, parse_button_function,
-    MOUSE_ACTIONS, SCROLL_ACTIONS, DPI_ACTIONS, PROFILE_ACTIONS,
+    MOUSE_ACTIONS, MOUSE_ACTION_ALIASES, SCROLL_ACTIONS, DPI_ACTIONS, PROFILE_ACTIONS,
     MEDIA_CODES, HID_MODS, HID_KEYS, XCLICK_ALIASES,
 )
 
@@ -2526,6 +2526,7 @@ class RemapButtonDialog(Adw.Window):
 
     def _preselect(self, spec: str):
         spec = (spec or '').strip().lower()
+        spec = MOUSE_ACTION_ALIASES.get(spec, spec)
         if not spec or spec == '–' or spec == 'disabled':
             self._category_row.set_selected(self._CATEGORIES.index('Disabled'))
             self._sub_row.set_visible(False)

--- a/src/pulsar_mouse/hid.py
+++ b/src/pulsar_mouse/hid.py
@@ -25,6 +25,13 @@ MOUSE_ACTIONS = {
 }
 MOUSE_ACTION_NAMES = {v: k for k, v in MOUSE_ACTIONS.items()}
 
+MOUSE_ACTION_ALIASES = {
+    'thumb1': 'forward',
+    'thumb2': 'backward',
+    'thumb3': 'forward',
+    'thumb4': 'backward',
+}
+
 # ── DPI actions (type 0x09) ─────────────────────────────────────────────────
 
 DPI_ACTIONS = {'dpi+': 0x01, 'dpi-': 0x02, 'dpiloop': 0x03}
@@ -144,6 +151,7 @@ def parse_button_function(spec: str) -> tuple[int, int, int]:
       disabled
     """
     s = spec.strip().lower()
+    s = MOUSE_ACTION_ALIASES.get(s, s)
 
     if s == 'disabled':
         return (BTN_TYPE_DISABLED, 0x00, 0x00)


### PR DESCRIPTION
The Pulsar X2A is an ambidextrous mouse with side buttons on both sides: Thumb 1 & 2 on the left, and Thumb 3 & 4 on the right.

The wired driver (x2a.py) already defined all four thumb buttons, but the Nordic driver (nordic.py) for the Pulsar X2A Wireless previously trimmed them down to 5 buttons due to unconfirmed addresses in the memory map.

Hardware testing on a live Pulsar X2A Wireless confirmed the real slot layout:
- 0x6C: Thumb 2 (Left Back)
- 0x70: Thumb 1 (Left Front)
- 0x74: DPI Button
- 0x78: Thumb 4 (Right Back)
- 0x7C: Thumb 3 (Right Front)

This restores thumb3, thumb4, and dpi to BUTTON_ADDRS, capabilities.buttons, and capabilities.button_labels in the Nordic driver.

Additionally:
- hid.py: adds MOUSE_ACTION_ALIASES so thumb1-thumb4 resolve to forward and backward in parse_button_function().
- gui.py: resolves action aliases in RemapButtonDialog._preselect().